### PR TITLE
Update compose.example.yml

### DIFF
--- a/compose.example.yml
+++ b/compose.example.yml
@@ -4,7 +4,6 @@ services:
     image: ghcr.io/yusing/godoxy-frontend:latest
     container_name: godoxy-frontend
     restart: unless-stopped
-    network_mode: host
     env_file: .env
     depends_on:
       - app


### PR DESCRIPTION
Network mode host is not needed for the frontend container and will only unnecessarily expose port 3000 via the host network.