### PR TITLE
fix: idle timeout container status

### DIFF
--- a/internal/idlewatcher/health.go
+++ b/internal/idlewatcher/health.go
@@ -102,11 +102,6 @@ func (w *Watcher) MarshalJSON() ([]byte, error) {
 }
 
 func (w *Watcher) checkUpdateState() (ready bool, err error) {
-	// the new container info not yet updated
-	if w.hc.URL().Host == "" {
-		return false, nil
-	}
-
 	state := w.state.Load()
 
 	// Check if container has been starting for too long (timeout after WakeTimeout)


### PR DESCRIPTION
Fixes #189 

Containers with `idle_timeout` and external networks were never marked as ready because the idlewatcher health check returned early when URL host was empty, blocking Docker-based health checks that don't require a URL.

## Changes

- **Removed early return in `checkUpdateState()`** that prevented health checks when `w.hc.URL().Host == ""`
  - Docker-based health checks (using Docker API) now run regardless of URL availability
  - URL-based health checks fail naturally with connection errors instead of being silently skipped

## Context

External networks may not populate Docker's `NetworkSettings`, leaving `PrivateHostname` and `PublicHostname` empty. The previous guard blocked all health check attempts, including Docker's native health status checks which operate independently of network configuration.

```go
// Before: blocked all health checks
if w.hc.URL().Host == "" {
    return false, nil
}

// After: allows Docker health checks, URL checks fail naturally
res, err := w.hc.CheckHealth()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved health check logic to rely on subsequent validation and timing mechanisms rather than early termination, enhancing robustness of the health monitoring system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->