### PR TITLE
feat: middleware bypass overlay

### DIFF
--- a/internal/entrypoint/README.md
+++ b/internal/entrypoint/README.md
@@ -11,7 +11,7 @@ The entrypoint package implements the primary HTTP handler that receives all inc
 - Domain-based route lookup with subdomain support
 - Short link (`go/<alias>` domain) handling
 - Middleware chain application
-- Route-specific promotion of bypass-only middleware overlays into matching entrypoint middleware
+- Route-specific promotion of middleware overlays into matching entrypoint middleware
 - Access logging for all requests
 - Configurable not-found handling
 - Per-domain route resolution

--- a/internal/entrypoint/README.md
+++ b/internal/entrypoint/README.md
@@ -11,6 +11,7 @@ The entrypoint package implements the primary HTTP handler that receives all inc
 - Domain-based route lookup with subdomain support
 - Short link (`go/<alias>` domain) handling
 - Middleware chain application
+- Route-specific promotion of bypass-only middleware overlays into matching entrypoint middleware
 - Access logging for all requests
 - Configurable not-found handling
 - Per-domain route resolution
@@ -101,6 +102,45 @@ type Config struct {
     AccessLog            *accesslog.RequestLoggerConfig `json:"access_log" validate:"omitempty"`
 }
 ```
+
+### Entrypoint middleware bypass overlays
+
+For HTTP routes, the entrypoint can compile a route-specific effective middleware chain when a route contributes a local middleware entry whose name matches an existing entrypoint middleware and whose options include `bypass`.
+
+Behavior is intentionally narrow:
+
+- only `bypass` is promoted in v1
+- promotion is **append-only**
+- the entrypoint middleware must already exist
+- if no matching entrypoint middleware exists, route-local behavior stays unchanged
+- when the route-local middleware entry is bypass-only, it is consumed after promotion so the same middleware is not evaluated twice
+
+Example:
+
+```yaml
+entrypoint:
+  middlewares:
+    - use: oidc
+
+routes:
+  app:
+    middlewares:
+      oidc:
+        bypass:
+          - path glob("/public/*")
+```
+
+This behaves as if the entrypoint middleware for that route had:
+
+```yaml
+entrypoint:
+  middlewares:
+    - use: oidc
+      bypass:
+        - route app & path glob("/public/*")
+```
+
+Pre-existing entrypoint bypass rules remain active; route bypass rules are added on top.
 
 `InboundMTLSProfile` references a named root-level inbound mTLS profile and enables Go's built-in client-certificate verification (`tls.RequireAndVerifyClientCert`) for all HTTPS traffic on the entrypoint.
 

--- a/internal/entrypoint/entrypoint.go
+++ b/internal/entrypoint/entrypoint.go
@@ -2,6 +2,7 @@ package entrypoint
 
 import (
 	"crypto/x509"
+	"maps"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -130,9 +131,17 @@ func (ep *Entrypoint) SetFindRouteDomains(domains []string) {
 }
 
 func (ep *Entrypoint) SetMiddlewares(mws []map[string]any) error {
+	ep.cfg.Middlewares = nil
 	if len(mws) == 0 {
 		ep.middleware = nil
+		for _, srv := range ep.servers.Range {
+			srv.resetRouteEntrypointOverlays()
+		}
 		return nil
+	}
+	ep.cfg.Middlewares = make([]map[string]any, len(mws))
+	for i, mw := range mws {
+		ep.cfg.Middlewares[i] = maps.Clone(mw)
 	}
 
 	mid, err := middleware.BuildMiddlewareFromChainRaw("entrypoint", mws)
@@ -140,6 +149,9 @@ func (ep *Entrypoint) SetMiddlewares(mws []map[string]any) error {
 		return err
 	}
 	ep.middleware = mid
+	for _, srv := range ep.servers.Range {
+		srv.resetRouteEntrypointOverlays()
+	}
 
 	log.Debug().Msg("entrypoint middleware loaded")
 	return nil

--- a/internal/entrypoint/entrypoint.go
+++ b/internal/entrypoint/entrypoint.go
@@ -131,17 +131,18 @@ func (ep *Entrypoint) SetFindRouteDomains(domains []string) {
 }
 
 func (ep *Entrypoint) SetMiddlewares(mws []map[string]any) error {
-	ep.cfg.Middlewares = nil
 	if len(mws) == 0 {
 		ep.middleware = nil
+		ep.cfg.Middlewares = nil
 		for _, srv := range ep.servers.Range {
 			srv.resetRouteEntrypointOverlays()
 		}
 		return nil
 	}
-	ep.cfg.Middlewares = make([]map[string]any, len(mws))
+
+	tmpMiddlewares := make([]map[string]any, len(mws))
 	for i, mw := range mws {
-		ep.cfg.Middlewares[i] = maps.Clone(mw)
+		tmpMiddlewares[i] = maps.Clone(mw)
 	}
 
 	mid, err := middleware.BuildMiddlewareFromChainRaw("entrypoint", mws)
@@ -149,6 +150,7 @@ func (ep *Entrypoint) SetMiddlewares(mws []map[string]any) error {
 		return err
 	}
 	ep.middleware = mid
+	ep.cfg.Middlewares = tmpMiddlewares
 	for _, srv := range ep.servers.Range {
 		srv.resetRouteEntrypointOverlays()
 	}

--- a/internal/entrypoint/entrypoint_overlay_test.go
+++ b/internal/entrypoint/entrypoint_overlay_test.go
@@ -1,0 +1,70 @@
+package entrypoint
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yusing/godoxy/internal/types"
+)
+
+func TestSetMiddlewaresInvalidatesRouteOverlayCache(t *testing.T) {
+	ep := NewTestEntrypoint(t, nil)
+	srv := newTestHTTPServer(t, ep)
+	route := newFakeHTTPRoute(t, "test-route", "")
+	route.routeMiddlewares = map[string]types.LabelMap{
+		"redirectHTTP": {
+			"bypass": "- path /health\n",
+		},
+	}
+	route.handler = func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}
+	srv.AddRoute(route)
+
+	require.NoError(t, ep.SetMiddlewares([]map[string]any{{
+		"use": "redirectHTTP",
+	}}))
+
+	first := httptest.NewRecorder()
+	srv.ServeHTTP(first, httptest.NewRequest(http.MethodGet, "http://test-route/private", nil))
+	require.Equal(t, http.StatusPermanentRedirect, first.Code)
+
+	require.NoError(t, ep.SetMiddlewares([]map[string]any{{
+		"use": "response",
+		"set_headers": map[string]string{
+			"X-Overlay-Reloaded": "true",
+		},
+	}}))
+
+	second := httptest.NewRecorder()
+	srv.ServeHTTP(second, httptest.NewRequest(http.MethodGet, "http://test-route/private", nil))
+	require.Equal(t, http.StatusNoContent, second.Code)
+	require.Equal(t, "true", second.Header().Get("X-Overlay-Reloaded"))
+}
+
+func TestServeHTTPHidesEntrypointOverlayCompilationErrors(t *testing.T) {
+	ep := NewTestEntrypoint(t, nil)
+	srv := newTestHTTPServer(t, ep)
+	route := newFakeHTTPRoute(t, "test-route", "")
+	route.routeMiddlewares = map[string]types.LabelMap{
+		"redirectHTTP": {
+			"bypass": "not-a-valid-bypass",
+		},
+	}
+	route.handler = func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}
+	srv.AddRoute(route)
+
+	require.NoError(t, ep.SetMiddlewares([]map[string]any{{
+		"use": "redirectHTTP",
+	}}))
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "http://test-route/", nil))
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Equal(t, "internal server error\n", rec.Body.String())
+}

--- a/internal/entrypoint/http_server.go
+++ b/internal/entrypoint/http_server.go
@@ -6,7 +6,9 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync/atomic"
 
+	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/rs/zerolog/log"
 	acl "github.com/yusing/godoxy/internal/acl/types"
 	autocert "github.com/yusing/godoxy/internal/autocert/types"
@@ -36,6 +38,18 @@ type httpServer struct {
 
 	addr   string
 	routes *pool.Pool[types.HTTPRoute]
+
+	routeEntrypointOverlays atomic.Pointer[xsync.Map[string, *routeEntrypointOverlay]]
+}
+
+type routeEntrypointOverlay struct {
+	middleware          *middleware.Middleware
+	consumedBypass      map[string]struct{}
+	consumedMiddlewares map[string]struct{}
+}
+
+func newRouteEntrypointOverlayMap() *xsync.Map[string, *routeEntrypointOverlay] {
+	return xsync.NewMap[string, *routeEntrypointOverlay]()
 }
 
 type HTTPProto string
@@ -50,7 +64,9 @@ func NewHTTPServer(ep *Entrypoint) HTTPServer {
 }
 
 func newHTTPServer(ep *Entrypoint) *httpServer {
-	return &httpServer{ep: ep}
+	srv := &httpServer{ep: ep}
+	srv.resetRouteEntrypointOverlays()
+	return srv
 }
 
 // Listen starts the server and stop when entrypoint is stopped.
@@ -102,10 +118,12 @@ func (srv *httpServer) Close() {
 
 func (srv *httpServer) AddRoute(route types.HTTPRoute) {
 	srv.routes.Add(route)
+	srv.routeEntrypointOverlayMap().Delete(route.Key())
 }
 
 func (srv *httpServer) DelRoute(route types.HTTPRoute) {
 	srv.routes.Del(route)
+	srv.routeEntrypointOverlayMap().Delete(route.Key())
 }
 
 func (srv *httpServer) FindRoute(s string) types.HTTPRoute {
@@ -135,10 +153,32 @@ func (srv *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	case route != nil:
 		r = routes.WithRouteContext(r, route)
-		if srv.ep.middleware != nil {
-			srv.ep.middleware.ServeHTTP(route.ServeHTTP, w, r)
+		entrypointMiddleware := srv.ep.middleware
+		next := route.ServeHTTP
+		if entrypointMiddleware != nil {
+			overlay, err := srv.getRouteEntrypointOverlay(route)
+			if err != nil {
+				log.Err(err).Str("route", route.Name()).Msg("failed to compile route-specific entrypoint middleware")
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+				return
+			}
+			if overlay != nil {
+				entrypointMiddleware = overlay.middleware
+				if len(overlay.consumedBypass) > 0 || len(overlay.consumedMiddlewares) > 0 {
+					next = func(w http.ResponseWriter, req *http.Request) {
+						route.ServeHTTP(w, middleware.WithConsumedRouteOverlays(
+							req,
+							overlay.consumedBypass,
+							overlay.consumedMiddlewares,
+						))
+					}
+				}
+			}
+		}
+		if entrypointMiddleware != nil {
+			entrypointMiddleware.ServeHTTP(next, w, r)
 		} else {
-			route.ServeHTTP(w, r)
+			next(w, r)
 		}
 	case srv.tryHandleShortLink(w, r):
 		return
@@ -147,6 +187,76 @@ func (srv *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		serveNotFound(w, r)
 	}
+}
+
+func (srv *httpServer) getRouteEntrypointOverlay(route types.HTTPRoute) (*routeEntrypointOverlay, error) {
+	if srv.ep.middleware == nil || len(srv.ep.cfg.Middlewares) == 0 {
+		return nil, nil
+	}
+	overlays := srv.routeEntrypointOverlayMap()
+	var buildErr error
+	overlay, _ := overlays.LoadOrCompute(route.Key(), func() (*routeEntrypointOverlay, bool) {
+		computed, err := srv.compileRouteEntrypointOverlay(route)
+		if err != nil {
+			buildErr = err
+			return nil, true
+		}
+		return computed, false
+	})
+	if buildErr != nil {
+		return nil, buildErr
+	}
+	if overlay.middleware == nil {
+		return nil, nil
+	}
+	return overlay, nil
+}
+
+func (srv *httpServer) routeEntrypointOverlayMap() *xsync.Map[string, *routeEntrypointOverlay] {
+	overlays := srv.routeEntrypointOverlays.Load()
+	if overlays != nil {
+		return overlays
+	}
+	overlays = newRouteEntrypointOverlayMap()
+	if srv.routeEntrypointOverlays.CompareAndSwap(nil, overlays) {
+		return overlays
+	}
+	return srv.routeEntrypointOverlays.Load()
+}
+
+func (srv *httpServer) resetRouteEntrypointOverlays() {
+	srv.routeEntrypointOverlays.Store(newRouteEntrypointOverlayMap())
+}
+
+func (srv *httpServer) compileRouteEntrypointOverlay(route types.HTTPRoute) (*routeEntrypointOverlay, error) {
+	routeMiddlewares := route.RouteMiddlewares()
+	if len(routeMiddlewares) == 0 {
+		return &routeEntrypointOverlay{}, nil
+	}
+
+	routeMiddlewareMap := make(map[string]middleware.OptionsRaw, len(routeMiddlewares))
+	for name, opts := range routeMiddlewares {
+		routeMiddlewareMap[name] = opts
+	}
+
+	compiled, err := middleware.BuildEntrypointRouteOverlay(
+		"entrypoint",
+		srv.ep.cfg.Middlewares,
+		route.Name(),
+		routeMiddlewareMap,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if compiled == nil {
+		return &routeEntrypointOverlay{}, nil
+	}
+
+	return &routeEntrypointOverlay{
+		middleware:          compiled.Middleware,
+		consumedBypass:      compiled.ConsumedBypass,
+		consumedMiddlewares: compiled.ConsumedMiddlewares,
+	}, nil
 }
 
 func (srv *httpServer) resolveRequestRoute(req *http.Request) (types.HTTPRoute, error) {

--- a/internal/entrypoint/http_server.go
+++ b/internal/entrypoint/http_server.go
@@ -3,7 +3,6 @@ package entrypoint
 import (
 	"errors"
 	"fmt"
-	"maps"
 	"net"
 	"net/http"
 	"strings"
@@ -232,13 +231,10 @@ func (srv *httpServer) resetRouteEntrypointOverlays() {
 }
 
 func (srv *httpServer) compileRouteEntrypointOverlay(route types.HTTPRoute) (*routeEntrypointOverlay, error) {
-	routeMiddlewares := route.RouteMiddlewares()
-	if len(routeMiddlewares) == 0 {
+	routeMiddlewareMap := route.RouteMiddlewares()
+	if len(routeMiddlewareMap) == 0 {
 		return &routeEntrypointOverlay{}, nil
 	}
-
-	routeMiddlewareMap := make(map[string]middleware.OptionsRaw, len(routeMiddlewares))
-	maps.Copy(routeMiddlewareMap, routeMiddlewares)
 
 	compiled, err := middleware.BuildEntrypointRouteOverlay(
 		"entrypoint",

--- a/internal/entrypoint/http_server.go
+++ b/internal/entrypoint/http_server.go
@@ -3,6 +3,7 @@ package entrypoint
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 	"strings"
@@ -47,6 +48,8 @@ type routeEntrypointOverlay struct {
 	consumedBypass      map[string]struct{}
 	consumedMiddlewares map[string]struct{}
 }
+
+var errNoRouteEntrypointOverlay = errors.New("no route entrypoint overlay")
 
 func newRouteEntrypointOverlayMap() *xsync.Map[string, *routeEntrypointOverlay] {
 	return xsync.NewMap[string, *routeEntrypointOverlay]()
@@ -157,7 +160,7 @@ func (srv *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		next := route.ServeHTTP
 		if entrypointMiddleware != nil {
 			overlay, err := srv.getRouteEntrypointOverlay(route)
-			if err != nil {
+			if err != nil && !errors.Is(err, errNoRouteEntrypointOverlay) {
 				log.Err(err).Str("route", route.Name()).Msg("failed to compile route-specific entrypoint middleware")
 				http.Error(w, "internal server error", http.StatusInternalServerError)
 				return
@@ -191,7 +194,7 @@ func (srv *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (srv *httpServer) getRouteEntrypointOverlay(route types.HTTPRoute) (*routeEntrypointOverlay, error) {
 	if srv.ep.middleware == nil || len(srv.ep.cfg.Middlewares) == 0 {
-		return nil, nil
+		return nil, errNoRouteEntrypointOverlay
 	}
 	overlays := srv.routeEntrypointOverlayMap()
 	var buildErr error
@@ -207,7 +210,7 @@ func (srv *httpServer) getRouteEntrypointOverlay(route types.HTTPRoute) (*routeE
 		return nil, buildErr
 	}
 	if overlay.middleware == nil {
-		return nil, nil
+		return nil, errNoRouteEntrypointOverlay
 	}
 	return overlay, nil
 }
@@ -235,9 +238,7 @@ func (srv *httpServer) compileRouteEntrypointOverlay(route types.HTTPRoute) (*ro
 	}
 
 	routeMiddlewareMap := make(map[string]middleware.OptionsRaw, len(routeMiddlewares))
-	for name, opts := range routeMiddlewares {
-		routeMiddlewareMap[name] = opts
-	}
+	maps.Copy(routeMiddlewareMap, routeMiddlewares)
 
 	compiled, err := middleware.BuildEntrypointRouteOverlay(
 		"entrypoint",
@@ -246,10 +247,10 @@ func (srv *httpServer) compileRouteEntrypointOverlay(route types.HTTPRoute) (*ro
 		routeMiddlewareMap,
 	)
 	if err != nil {
+		if errors.Is(err, middleware.ErrNoEntrypointRouteOverlay) {
+			return &routeEntrypointOverlay{}, nil
+		}
 		return nil, err
-	}
-	if compiled == nil {
-		return &routeEntrypointOverlay{}, nil
 	}
 
 	return &routeEntrypointOverlay{

--- a/internal/entrypoint/inbound_mtls_test.go
+++ b/internal/entrypoint/inbound_mtls_test.go
@@ -31,6 +31,8 @@ type fakeHTTPRoute struct {
 	name               string
 	inboundMTLSProfile string
 	listenURL          *nettypes.URL
+	routeMiddlewares   map[string]types.LabelMap
+	handler            http.HandlerFunc
 	task               *task.Task
 }
 
@@ -88,10 +90,13 @@ func (r *fakeHTTPRoute) UseLoadBalance() bool       { return false }
 func (r *fakeHTTPRoute) UseIdleWatcher() bool       { return false }
 func (r *fakeHTTPRoute) UseHealthCheck() bool       { return false }
 func (r *fakeHTTPRoute) UseAccessLog() bool         { return false }
-func (r *fakeHTTPRoute) ServeHTTP(http.ResponseWriter, *http.Request) {
-	// no-op: test stub
+func (r *fakeHTTPRoute) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if r.handler != nil {
+		r.handler(w, req)
+	}
 }
-func (r *fakeHTTPRoute) InboundMTLSProfileRef() string { return r.inboundMTLSProfile }
+func (r *fakeHTTPRoute) InboundMTLSProfileRef() string               { return r.inboundMTLSProfile }
+func (r *fakeHTTPRoute) RouteMiddlewares() map[string]types.LabelMap { return r.routeMiddlewares }
 
 func newTestHTTPServer(t *testing.T, ep *Entrypoint) *httpServer {
 	t.Helper()
@@ -106,6 +111,7 @@ func newTestHTTPServer(t *testing.T, ep *Entrypoint) *httpServer {
 		addr:   common.ProxyHTTPAddr,
 		routes: pool.New[types.HTTPRoute]("test-http-routes", "test-http-routes"),
 	}
+	srv.resetRouteEntrypointOverlays()
 	ep.servers.Store(common.ProxyHTTPAddr, srv)
 	return srv
 }

--- a/internal/net/gphttp/middleware/README.md
+++ b/internal/net/gphttp/middleware/README.md
@@ -11,6 +11,7 @@ This package implements a flexible HTTP middleware system for GoDoxy. Middleware
 - **Middleware Chaining**: Compose multiple middleware in priority order
 - **YAML Composition**: Define middleware chains in configuration files
 - **Bypass Rules**: Skip middleware based on request properties
+- **Entrypoint Overlay Promotion**: Promote route-local bypass-only overlays into matching entrypoint middleware for HTTP routes
 - **Dynamic Loading**: Load middleware definitions from files at runtime
 
 Response body rewriting is only applied to unencoded, text-like content types (for example `text/*`, JSON, YAML, XML). Response status and headers can always be modified.
@@ -140,6 +141,42 @@ type Bypass []rules.RuleOn
 func (b Bypass) ShouldBypass(w http.ResponseWriter, r *http.Request) bool
 ```
 
+For HTTP routes, any route-local middleware entry that sets `bypass` and matches an existing entrypoint middleware name contributes an overlay: its bypass rules are promoted into the effective entrypoint middleware for that route.
+
+Semantics:
+
+- promotion is **bypass-only** in v1
+- promoted rules are qualified as `route <alias> & <rule>`
+- existing entrypoint bypass rules are preserved and the route rules are appended
+- if the route-local middleware entry contains only `bypass`, it is consumed so the same middleware is not evaluated twice
+- if the route-local middleware entry contains additional options, only the bypass portion is consumed; the rest of the route-local middleware still executes normally
+- if no matching entrypoint middleware exists, route-local middleware behavior is unchanged
+
+Example:
+
+```yaml
+entrypoint:
+  middlewares:
+    - use: oidc
+
+routes:
+  app:
+    middlewares:
+      oidc:
+        bypass:
+          - path glob("/public/*")
+```
+
+Effective behavior for route `app` is equivalent to:
+
+```yaml
+entrypoint:
+  middlewares:
+    - use: oidc
+      bypass:
+        - route app & path glob("/public/*")
+```
+
 ## Available Middleware
 
 | Name                            | Type     | Description                                |
@@ -246,6 +283,8 @@ if err != nil {
     log.Fatal(err)
 }
 ```
+
+`PatchReverseProxy` still handles route-local middleware in the normal way. Entrypoint overlay promotion happens earlier, at entrypoint request dispatch time, where the server has both the resolved route and the raw entrypoint middleware definitions available.
 
 ### Bypass Rules
 

--- a/internal/net/gphttp/middleware/README.md
+++ b/internal/net/gphttp/middleware/README.md
@@ -11,7 +11,7 @@ This package implements a flexible HTTP middleware system for GoDoxy. Middleware
 - **Middleware Chaining**: Compose multiple middleware in priority order
 - **YAML Composition**: Define middleware chains in configuration files
 - **Bypass Rules**: Skip middleware based on request properties
-- **Entrypoint Overlay Promotion**: Promote route-local bypass-only overlays into matching entrypoint middleware for HTTP routes
+- **Entrypoint Overlay Promotion**: Promote route-local middleware entries with `bypass` into matching entrypoint middleware for HTTP routes
 - **Dynamic Loading**: Load middleware definitions from files at runtime
 
 Response body rewriting is only applied to unencoded, text-like content types (for example `text/*`, JSON, YAML, XML). Response status and headers can always be modified.
@@ -145,10 +145,10 @@ For HTTP routes, any route-local middleware entry that sets `bypass` and matches
 
 Semantics:
 
-- promotion is **bypass-only** in v1
+- route-local middleware entries may be promoted when they include `bypass`; only the bypass portion is promoted in v1
 - promoted rules are qualified as `route <alias> & <rule>`
 - existing entrypoint bypass rules are preserved and the route rules are appended
-- if the route-local middleware entry contains only `bypass`, it is consumed so the same middleware is not evaluated twice
+- if the route-local middleware entry is **bypass-only**, it is consumed so the same middleware is not evaluated twice
 - if the route-local middleware entry contains additional options, only the bypass portion is consumed; the rest of the route-local middleware still executes normally
 - if no matching entrypoint middleware exists, route-local middleware behavior is unchanged
 

--- a/internal/net/gphttp/middleware/bypass.go
+++ b/internal/net/gphttp/middleware/bypass.go
@@ -82,6 +82,9 @@ func (c *checkBypass) shouldModReqBypass(w http.ResponseWriter, r *http.Request)
 			return true
 		}
 	}
+	if isRouteBypassPromoted(r, c.name) {
+		return false
+	}
 	return c.bypass.ShouldBypass(w, r)
 }
 
@@ -99,6 +102,9 @@ func (c *checkBypass) shouldModResBypass(resp *http.Response) bool {
 			return true
 		}
 	}
+	if isRouteBypassPromoted(resp.Request, c.name) {
+		return false
+	}
 	return c.bypass.ShouldBypass(httputils.ResponseAsRW(resp), resp.Request)
 }
 
@@ -106,6 +112,9 @@ func (c *checkBypass) shouldModResBypass(resp *http.Response) bool {
 //
 // Returns true if the request is not done, false otherwise.
 func (c *checkBypass) before(w http.ResponseWriter, r *http.Request) (proceedNext bool) {
+	if isRouteMiddlewareConsumed(r, c.name) {
+		return true
+	}
 	if c.modReq == nil || c.shouldModReqBypass(w, r) {
 		return true
 	}
@@ -115,6 +124,9 @@ func (c *checkBypass) before(w http.ResponseWriter, r *http.Request) (proceedNex
 
 // modifyResponse modifies the response if the response should be modified.
 func (c *checkBypass) modifyResponse(resp *http.Response) error {
+	if isRouteMiddlewareConsumed(resp.Request, c.name) {
+		return nil
+	}
 	if c.modRes == nil || c.shouldModResBypass(resp) {
 		return nil
 	}

--- a/internal/net/gphttp/middleware/bypass_test.go
+++ b/internal/net/gphttp/middleware/bypass_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/yusing/godoxy/internal/entrypoint"
 	. "github.com/yusing/godoxy/internal/net/gphttp/middleware"
 	"github.com/yusing/godoxy/internal/route"
@@ -275,13 +277,13 @@ func TestEntrypointPromotesRouteBypassOverlay(t *testing.T) {
 	defer srv.Close()
 
 	targetURL, err := url.Parse(srv.URL)
-	expect.NoError(t, err)
+	require.NoError(t, err)
 
 	host, port, err := net.SplitHostPort(targetURL.Host)
-	expect.NoError(t, err)
+	require.NoError(t, err)
 
 	portInt, err := strconv.Atoi(port)
-	expect.NoError(t, err)
+	require.NoError(t, err)
 
 	entry := entrypoint.NewTestEntrypoint(t, nil)
 	_, err = route.NewStartedTestRoute(t, &route.Route{
@@ -300,7 +302,7 @@ func TestEntrypointPromotesRouteBypassOverlay(t *testing.T) {
 			},
 		},
 	})
-	expect.NoError(t, err)
+	require.NoError(t, err)
 
 	err = entry.SetMiddlewares([]map[string]any{
 		{
@@ -308,12 +310,10 @@ func TestEntrypointPromotesRouteBypassOverlay(t *testing.T) {
 			"bypass": []string{"path /health"},
 		},
 	})
-	expect.NoError(t, err)
+	require.NoError(t, err)
 
 	server, ok := entry.GetServer(":1000")
-	if !ok {
-		t.Fatal("server not found")
-	}
+	require.True(t, ok, "server not found")
 
 	tests := []struct {
 		name         string
@@ -347,11 +347,11 @@ func TestEntrypointPromotesRouteBypassOverlay(t *testing.T) {
 			recorder := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "http://test-route.example.com"+test.path, nil)
 			server.ServeHTTP(recorder, req)
-			expect.Equal(t, recorder.Code, test.expectStatus)
+			assert.Equal(t, test.expectStatus, recorder.Code)
 			if test.expectBody != "" {
-				expect.Equal(t, recorder.Body.String(), test.expectBody)
+				assert.Equal(t, test.expectBody, recorder.Body.String())
 			}
-			expect.Equal(t, recorder.Header().Get("Location"), test.expectLoc)
+			assert.Equal(t, test.expectLoc, recorder.Header().Get("Location"))
 		})
 	}
 }
@@ -363,13 +363,13 @@ func TestRouteBypassWithoutMatchingEntrypointMiddlewareKeepsCurrentBehavior(t *t
 	defer srv.Close()
 
 	targetURL, err := url.Parse(srv.URL)
-	expect.NoError(t, err)
+	require.NoError(t, err)
 
 	host, port, err := net.SplitHostPort(targetURL.Host)
-	expect.NoError(t, err)
+	require.NoError(t, err)
 
 	portInt, err := strconv.Atoi(port)
-	expect.NoError(t, err)
+	require.NoError(t, err)
 
 	entry := entrypoint.NewTestEntrypoint(t, nil)
 	_, err = route.NewStartedTestRoute(t, &route.Route{
@@ -388,26 +388,31 @@ func TestRouteBypassWithoutMatchingEntrypointMiddlewareKeepsCurrentBehavior(t *t
 			},
 		},
 	})
-	expect.NoError(t, err)
+	require.NoError(t, err)
+
+	require.NoError(t, entry.SetMiddlewares([]map[string]any{{
+		"use": "response",
+		"set_headers": map[string]string{
+			"X-Entrypoint-Overlay": "true",
+		},
+	}}))
 
 	server, ok := entry.GetServer(":1000")
-	if !ok {
-		t.Fatal("server not found")
-	}
+	require.True(t, ok, "server not found")
 
 	t.Run("bypass_still_works_without_matching_entrypoint_middleware", func(t *testing.T) {
 		recorder := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "http://test-route.example.com/public/index.html", nil)
 		server.ServeHTTP(recorder, req)
-		expect.Equal(t, recorder.Code, http.StatusOK)
-		expect.Equal(t, recorder.Body.String(), "test")
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "test", recorder.Body.String())
 	})
 
 	t.Run("route_middleware_still_redirects_for_non_matching_paths", func(t *testing.T) {
 		recorder := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "http://test-route.example.com/private", nil)
 		server.ServeHTTP(recorder, req)
-		expect.Equal(t, recorder.Code, http.StatusPermanentRedirect)
-		expect.Equal(t, recorder.Header().Get("Location"), "https://test-route.example.com/private")
+		assert.Equal(t, http.StatusPermanentRedirect, recorder.Code)
+		assert.Equal(t, "https://test-route.example.com/private", recorder.Header().Get("Location"))
 	})
 }

--- a/internal/net/gphttp/middleware/bypass_test.go
+++ b/internal/net/gphttp/middleware/bypass_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/yusing/godoxy/internal/net/gphttp/middleware"
 	"github.com/yusing/godoxy/internal/route"
 	routeTypes "github.com/yusing/godoxy/internal/route/types"
+	"github.com/yusing/godoxy/internal/types"
 	"github.com/yusing/goutils/http/reverseproxy"
 	expect "github.com/yusing/goutils/testing"
 )
@@ -265,4 +266,148 @@ func TestEntrypointBypassRoute(t *testing.T) {
 	expect.Equal(t, recorder.Code, http.StatusOK, "should bypass http redirect")
 	expect.Equal(t, recorder.Body.String(), "test")
 	expect.Equal(t, recorder.Header().Get("Test-Header"), "test-value")
+}
+
+func TestEntrypointPromotesRouteBypassOverlay(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("test"))
+	}))
+	defer srv.Close()
+
+	targetURL, err := url.Parse(srv.URL)
+	expect.NoError(t, err)
+
+	host, port, err := net.SplitHostPort(targetURL.Host)
+	expect.NoError(t, err)
+
+	portInt, err := strconv.Atoi(port)
+	expect.NoError(t, err)
+
+	entry := entrypoint.NewTestEntrypoint(t, nil)
+	_, err = route.NewStartedTestRoute(t, &route.Route{
+		Alias:  "test-route",
+		Scheme: routeTypes.SchemeHTTP,
+		Host:   host,
+		Port: routeTypes.Port{
+			Listening: 1000,
+			Proxy:     portInt,
+		},
+		Middlewares: map[string]types.LabelMap{
+			"redirectHTTP": {
+				"bypass": `
+- path glob(/public/*)
+`[1:],
+			},
+		},
+	})
+	expect.NoError(t, err)
+
+	err = entry.SetMiddlewares([]map[string]any{
+		{
+			"use":    "redirectHTTP",
+			"bypass": []string{"path /health"},
+		},
+	})
+	expect.NoError(t, err)
+
+	server, ok := entry.GetServer(":1000")
+	if !ok {
+		t.Fatal("server not found")
+	}
+
+	tests := []struct {
+		name         string
+		path         string
+		expectStatus int
+		expectBody   string
+		expectLoc    string
+	}{
+		{
+			name:         "existing_entrypoint_bypass_still_applies",
+			path:         "/health",
+			expectStatus: http.StatusOK,
+			expectBody:   "test",
+		},
+		{
+			name:         "route_bypass_is_promoted_to_entrypoint",
+			path:         "/public/index.html",
+			expectStatus: http.StatusOK,
+			expectBody:   "test",
+		},
+		{
+			name:         "non_matching_path_still_redirects",
+			path:         "/private",
+			expectStatus: http.StatusPermanentRedirect,
+			expectLoc:    "https://test-route.example.com/private",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "http://test-route.example.com"+test.path, nil)
+			server.ServeHTTP(recorder, req)
+			expect.Equal(t, recorder.Code, test.expectStatus)
+			if test.expectBody != "" {
+				expect.Equal(t, recorder.Body.String(), test.expectBody)
+			}
+			expect.Equal(t, recorder.Header().Get("Location"), test.expectLoc)
+		})
+	}
+}
+
+func TestRouteBypassWithoutMatchingEntrypointMiddlewareKeepsCurrentBehavior(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("test"))
+	}))
+	defer srv.Close()
+
+	targetURL, err := url.Parse(srv.URL)
+	expect.NoError(t, err)
+
+	host, port, err := net.SplitHostPort(targetURL.Host)
+	expect.NoError(t, err)
+
+	portInt, err := strconv.Atoi(port)
+	expect.NoError(t, err)
+
+	entry := entrypoint.NewTestEntrypoint(t, nil)
+	_, err = route.NewStartedTestRoute(t, &route.Route{
+		Alias:  "test-route",
+		Scheme: routeTypes.SchemeHTTP,
+		Host:   host,
+		Port: routeTypes.Port{
+			Listening: 1000,
+			Proxy:     portInt,
+		},
+		Middlewares: map[string]types.LabelMap{
+			"redirectHTTP": {
+				"bypass": `
+- path glob(/public/*)
+`[1:],
+			},
+		},
+	})
+	expect.NoError(t, err)
+
+	server, ok := entry.GetServer(":1000")
+	if !ok {
+		t.Fatal("server not found")
+	}
+
+	t.Run("bypass_still_works_without_matching_entrypoint_middleware", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "http://test-route.example.com/public/index.html", nil)
+		server.ServeHTTP(recorder, req)
+		expect.Equal(t, recorder.Code, http.StatusOK)
+		expect.Equal(t, recorder.Body.String(), "test")
+	})
+
+	t.Run("route_middleware_still_redirects_for_non_matching_paths", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "http://test-route.example.com/private", nil)
+		server.ServeHTTP(recorder, req)
+		expect.Equal(t, recorder.Code, http.StatusPermanentRedirect)
+		expect.Equal(t, recorder.Header().Get("Location"), "https://test-route.example.com/private")
+	})
 }

--- a/internal/net/gphttp/middleware/entrypoint_overlay.go
+++ b/internal/net/gphttp/middleware/entrypoint_overlay.go
@@ -1,0 +1,170 @@
+package middleware
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/yusing/godoxy/internal/route/rules"
+	"github.com/yusing/godoxy/internal/serialization"
+	strutils "github.com/yusing/goutils/strings"
+)
+
+type EntrypointRouteOverlay struct {
+	Middleware          *Middleware
+	ConsumedBypass      map[string]struct{}
+	ConsumedMiddlewares map[string]struct{}
+}
+
+type bypassOnlyField struct {
+	Bypass Bypass `json:"bypass"`
+}
+
+// BuildEntrypointRouteOverlay promotes route-level bypass rules into a copy of the entrypoint middleware
+// chain. For each route middleware entry in routeMiddlewares that sets "bypass", it finds the entrypoint
+// definition with the same "use" name (case-insensitive, snake-agnostic) and appends those rules after
+// qualifying them with the route (each rule becomes "route <routeName> & <original>").
+//
+// name is the logical chain name passed to [BuildMiddlewareFromChainRaw].
+//
+// It returns (nil, nil) when entrypointDefs or routeMiddlewares is empty, or when no route bypass was
+// merged into any entrypoint definition. On success, ConsumedBypass lists normalized middleware names
+// whose bypass was applied; ConsumedMiddlewares lists names whose route options contained only "bypass",
+// so downstream handling can treat those overlay-only route entries as fully satisfied. Route middleware
+// entries with additional options still run at route scope after promotion.
+//
+// Errors wrap parse/merge failures for bypass values or route qualification.
+func BuildEntrypointRouteOverlay(
+	name string,
+	entrypointDefs []map[string]any,
+	routeName string,
+	routeMiddlewares map[string]OptionsRaw,
+) (*EntrypointRouteOverlay, error) {
+	if len(entrypointDefs) == 0 || len(routeMiddlewares) == 0 {
+		return nil, nil
+	}
+
+	effectiveDefs := cloneMiddlewareDefs(entrypointDefs)
+	var consumedBypass map[string]struct{}
+	var consumedMiddlewares map[string]struct{}
+	promotedAny := false
+
+	for routeMiddlewareName, routeOpts := range routeMiddlewares {
+		routeBypass, ok, err := parseBypassValue(routeOpts["bypass"])
+		if err != nil {
+			return nil, fmt.Errorf("route middleware %q bypass: %w", routeMiddlewareName, err)
+		}
+		if !ok || len(routeBypass) == 0 {
+			continue
+		}
+
+		promotedBypass, err := qualifyBypassWithRoute(routeName, routeBypass)
+		if err != nil {
+			return nil, fmt.Errorf("route middleware %q bypass promotion: %w", routeMiddlewareName, err)
+		}
+
+		matched := false
+		for i, def := range effectiveDefs {
+			use, _ := def["use"].(string)
+			if strutils.ToLowerNoSnake(use) != strutils.ToLowerNoSnake(routeMiddlewareName) {
+				continue
+			}
+
+			mergedBypass, err := appendBypassValue(def["bypass"], promotedBypass)
+			if err != nil {
+				return nil, fmt.Errorf("entrypoint middleware %q bypass merge: %w", use, err)
+			}
+
+			def = maps.Clone(def)
+			def["bypass"] = mergedBypass
+			effectiveDefs[i] = def
+			matched = true
+		}
+		if !matched {
+			continue
+		}
+
+		promotedAny = true
+		if consumedBypass == nil {
+			consumedBypass = make(map[string]struct{})
+		}
+		normalizedName := strutils.ToLowerNoSnake(routeMiddlewareName)
+		consumedBypass[normalizedName] = struct{}{}
+		if isBypassOnlyOptions(routeOpts) {
+			if consumedMiddlewares == nil {
+				consumedMiddlewares = make(map[string]struct{})
+			}
+			consumedMiddlewares[normalizedName] = struct{}{}
+		}
+	}
+
+	if !promotedAny {
+		return nil, nil
+	}
+
+	mid, err := BuildMiddlewareFromChainRaw(name, effectiveDefs)
+	if err != nil {
+		return nil, err
+	}
+	return &EntrypointRouteOverlay{
+		Middleware:          mid,
+		ConsumedBypass:      consumedBypass,
+		ConsumedMiddlewares: consumedMiddlewares,
+	}, nil
+}
+
+func cloneMiddlewareDefs(defs []map[string]any) []map[string]any {
+	cloned := make([]map[string]any, len(defs))
+	for i, def := range defs {
+		// Shallow clone is intentional: overlay promotion only replaces the top-level
+		// bypass field and leaves nested option values untouched.
+		cloned[i] = maps.Clone(def)
+	}
+	return cloned
+}
+
+func appendBypassValue(existing any, promoted Bypass) (Bypass, error) {
+	current, ok, err := parseBypassValue(existing)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return slices.Clone(promoted), nil
+	}
+	return append(slices.Clone(current), promoted...), nil
+}
+
+func parseBypassValue(raw any) (Bypass, bool, error) {
+	if raw == nil {
+		return nil, false, nil
+	}
+	var dst bypassOnlyField
+	if err := serialization.MapUnmarshalValidate(map[string]any{"bypass": raw}, &dst); err != nil {
+		return nil, true, err
+	}
+	return dst.Bypass, true, nil
+}
+
+func qualifyBypassWithRoute(routeName string, bypass Bypass) (Bypass, error) {
+	qualified := make(Bypass, len(bypass))
+	for i, rule := range bypass {
+		var routeQualified rules.RuleOn
+		if err := routeQualified.Parse(fmt.Sprintf("route %s & %s", routeName, rule.String())); err != nil {
+			return nil, err
+		}
+		qualified[i] = routeQualified
+	}
+	return qualified, nil
+}
+
+func isBypassOnlyOptions(opts OptionsRaw) bool {
+	if len(opts) == 0 {
+		return false
+	}
+	for key := range opts {
+		if strutils.ToLowerNoSnake(key) != "bypass" {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/net/gphttp/middleware/entrypoint_overlay.go
+++ b/internal/net/gphttp/middleware/entrypoint_overlay.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -20,6 +21,8 @@ type bypassOnlyField struct {
 	Bypass Bypass `json:"bypass"`
 }
 
+var ErrNoEntrypointRouteOverlay = errors.New("no entrypoint route overlay")
+
 // BuildEntrypointRouteOverlay promotes route-level bypass rules into a copy of the entrypoint middleware
 // chain. For each route middleware entry in routeMiddlewares that sets "bypass", it finds the entrypoint
 // definition with the same "use" name (case-insensitive, snake-agnostic) and appends those rules after
@@ -27,11 +30,11 @@ type bypassOnlyField struct {
 //
 // name is the logical chain name passed to [BuildMiddlewareFromChainRaw].
 //
-// It returns (nil, nil) when entrypointDefs or routeMiddlewares is empty, or when no route bypass was
-// merged into any entrypoint definition. On success, ConsumedBypass lists normalized middleware names
-// whose bypass was applied; ConsumedMiddlewares lists names whose route options contained only "bypass",
-// so downstream handling can treat those overlay-only route entries as fully satisfied. Route middleware
-// entries with additional options still run at route scope after promotion.
+// It returns [ErrNoEntrypointRouteOverlay] when entrypointDefs or routeMiddlewares is empty, or when no
+// route bypass was merged into any entrypoint definition. On success, ConsumedBypass lists normalized
+// middleware names whose bypass was applied; ConsumedMiddlewares lists names whose route options contained
+// only "bypass", so downstream handling can treat those overlay-only route entries as fully satisfied.
+// Route middleware entries with additional options still run at route scope after promotion.
 //
 // Errors wrap parse/merge failures for bypass values or route qualification.
 func BuildEntrypointRouteOverlay(
@@ -41,7 +44,7 @@ func BuildEntrypointRouteOverlay(
 	routeMiddlewares map[string]OptionsRaw,
 ) (*EntrypointRouteOverlay, error) {
 	if len(entrypointDefs) == 0 || len(routeMiddlewares) == 0 {
-		return nil, nil
+		return nil, ErrNoEntrypointRouteOverlay
 	}
 
 	effectiveDefs := cloneMiddlewareDefs(entrypointDefs)
@@ -99,7 +102,7 @@ func BuildEntrypointRouteOverlay(
 	}
 
 	if !promotedAny {
-		return nil, nil
+		return nil, ErrNoEntrypointRouteOverlay
 	}
 
 	mid, err := BuildMiddlewareFromChainRaw(name, effectiveDefs)

--- a/internal/net/gphttp/middleware/entrypoint_overlay.go
+++ b/internal/net/gphttp/middleware/entrypoint_overlay.go
@@ -53,52 +53,29 @@ func BuildEntrypointRouteOverlay(
 	promotedAny := false
 
 	for routeMiddlewareName, routeOpts := range routeMiddlewares {
-		routeBypass, ok, err := parseBypassValue(routeOpts["bypass"])
+		promotedBypass, ok, err := buildPromotedRouteBypass(routeName, routeMiddlewareName, routeOpts)
 		if err != nil {
-			return nil, fmt.Errorf("route middleware %q bypass: %w", routeMiddlewareName, err)
+			return nil, err
 		}
-		if !ok || len(routeBypass) == 0 {
+		if !ok {
 			continue
 		}
 
-		promotedBypass, err := qualifyBypassWithRoute(routeName, routeBypass)
+		matched, err := mergePromotedBypassIntoEffectiveDefs(effectiveDefs, routeMiddlewareName, promotedBypass)
 		if err != nil {
-			return nil, fmt.Errorf("route middleware %q bypass promotion: %w", routeMiddlewareName, err)
-		}
-
-		matched := false
-		for i, def := range effectiveDefs {
-			use, _ := def["use"].(string)
-			if strutils.ToLowerNoSnake(use) != strutils.ToLowerNoSnake(routeMiddlewareName) {
-				continue
-			}
-
-			mergedBypass, err := appendBypassValue(def["bypass"], promotedBypass)
-			if err != nil {
-				return nil, fmt.Errorf("entrypoint middleware %q bypass merge: %w", use, err)
-			}
-
-			def = maps.Clone(def)
-			def["bypass"] = mergedBypass
-			effectiveDefs[i] = def
-			matched = true
+			return nil, err
 		}
 		if !matched {
 			continue
 		}
 
 		promotedAny = true
-		if consumedBypass == nil {
-			consumedBypass = make(map[string]struct{})
-		}
-		normalizedName := strutils.ToLowerNoSnake(routeMiddlewareName)
-		consumedBypass[normalizedName] = struct{}{}
-		if isBypassOnlyOptions(routeOpts) {
-			if consumedMiddlewares == nil {
-				consumedMiddlewares = make(map[string]struct{})
-			}
-			consumedMiddlewares[normalizedName] = struct{}{}
-		}
+		consumedBypass, consumedMiddlewares = recordPromotedRouteOverlayConsumption(
+			consumedBypass,
+			consumedMiddlewares,
+			routeMiddlewareName,
+			routeOpts,
+		)
 	}
 
 	if !promotedAny {
@@ -114,6 +91,66 @@ func BuildEntrypointRouteOverlay(
 		ConsumedBypass:      consumedBypass,
 		ConsumedMiddlewares: consumedMiddlewares,
 	}, nil
+}
+
+func buildPromotedRouteBypass(routeName, routeMiddlewareName string, routeOpts OptionsRaw) (Bypass, bool, error) {
+	routeBypass, ok, err := parseBypassValue(routeOpts["bypass"])
+	if err != nil {
+		return nil, false, fmt.Errorf("route middleware %q bypass: %w", routeMiddlewareName, err)
+	}
+	if !ok || len(routeBypass) == 0 {
+		return nil, false, nil
+	}
+
+	promotedBypass, err := qualifyBypassWithRoute(routeName, routeBypass)
+	if err != nil {
+		return nil, false, fmt.Errorf("route middleware %q bypass promotion: %w", routeMiddlewareName, err)
+	}
+	return promotedBypass, true, nil
+}
+
+func mergePromotedBypassIntoEffectiveDefs(effectiveDefs []map[string]any, routeMiddlewareName string, promotedBypass Bypass) (bool, error) {
+	normalizedRouteMiddlewareName := strutils.ToLowerNoSnake(routeMiddlewareName)
+	matched := false
+	for i, def := range effectiveDefs {
+		use, _ := def["use"].(string)
+		if strutils.ToLowerNoSnake(use) != normalizedRouteMiddlewareName {
+			continue
+		}
+
+		mergedBypass, err := appendBypassValue(def["bypass"], promotedBypass)
+		if err != nil {
+			return false, fmt.Errorf("entrypoint middleware %q bypass merge: %w", use, err)
+		}
+
+		clonedDef := maps.Clone(def)
+		clonedDef["bypass"] = mergedBypass
+		effectiveDefs[i] = clonedDef
+		matched = true
+	}
+	return matched, nil
+}
+
+func recordPromotedRouteOverlayConsumption(
+	consumedBypass map[string]struct{},
+	consumedMiddlewares map[string]struct{},
+	routeMiddlewareName string,
+	routeOpts OptionsRaw,
+) (map[string]struct{}, map[string]struct{}) {
+	normalizedName := strutils.ToLowerNoSnake(routeMiddlewareName)
+	if consumedBypass == nil {
+		consumedBypass = make(map[string]struct{})
+	}
+	consumedBypass[normalizedName] = struct{}{}
+
+	if !isBypassOnlyOptions(routeOpts) {
+		return consumedBypass, consumedMiddlewares
+	}
+	if consumedMiddlewares == nil {
+		consumedMiddlewares = make(map[string]struct{})
+	}
+	consumedMiddlewares[normalizedName] = struct{}{}
+	return consumedBypass, consumedMiddlewares
 }
 
 func cloneMiddlewareDefs(defs []map[string]any) []map[string]any {

--- a/internal/net/gphttp/middleware/entrypoint_overlay_test.go
+++ b/internal/net/gphttp/middleware/entrypoint_overlay_test.go
@@ -60,3 +60,25 @@ func TestBuildEntrypointRouteOverlayPromotesRouteBypass(t *testing.T) {
 	require.Contains(t, overlay.ConsumedBypass, "redirecthttp")
 	require.Contains(t, overlay.ConsumedMiddlewares, "redirecthttp")
 }
+
+func TestBuildEntrypointRouteOverlayKeepsNonBypassRouteMiddlewareActive(t *testing.T) {
+	overlay, err := BuildEntrypointRouteOverlay(
+		"entrypoint",
+		[]map[string]any{{
+			"use": "redirectHTTP",
+		}},
+		"test-route",
+		map[string]OptionsRaw{
+			"redirectHTTP": {
+				"bypass":       []string{"path /health"},
+				"redirectHTTP": "https://example.com",
+			},
+		},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, overlay)
+	require.NotNil(t, overlay.Middleware)
+	require.Contains(t, overlay.ConsumedBypass, "redirecthttp")
+	require.Empty(t, overlay.ConsumedMiddlewares)
+}

--- a/internal/net/gphttp/middleware/entrypoint_overlay_test.go
+++ b/internal/net/gphttp/middleware/entrypoint_overlay_test.go
@@ -1,9 +1,12 @@
 package middleware
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/yusing/godoxy/internal/route/routes"
+	"github.com/yusing/godoxy/internal/route/rules"
 )
 
 func TestBuildEntrypointRouteOverlayReturnsSentinelWhenNoPromotionOccurs(t *testing.T) {
@@ -81,4 +84,26 @@ func TestBuildEntrypointRouteOverlayKeepsNonBypassRouteMiddlewareActive(t *testi
 	require.NotNil(t, overlay.Middleware)
 	require.Contains(t, overlay.ConsumedBypass, "redirecthttp")
 	require.Empty(t, overlay.ConsumedMiddlewares)
+}
+
+func TestQualifyBypassWithRoutePreservesCompositeRuleSemantics(t *testing.T) {
+	var composite rules.RuleOn
+	require.NoError(t, composite.Parse("path /health | path /status"))
+
+	qualified, err := qualifyBypassWithRoute("test-route", Bypass{composite})
+	require.NoError(t, err)
+	require.Len(t, qualified, 1)
+
+	matches := func(path, routeName string) bool {
+		req := httptest.NewRequest("GET", "http://example.com"+path, nil)
+		if routeName != "" {
+			req = routes.WithRouteContext(req, fakeMiddlewareHTTPRoute{name: routeName})
+		}
+		return qualified[0].Check(httptest.NewRecorder(), req)
+	}
+
+	require.True(t, matches("/health", "test-route"))
+	require.True(t, matches("/status", "test-route"))
+	require.False(t, matches("/health", "other-route"))
+	require.False(t, matches("/metrics", "test-route"))
 }

--- a/internal/net/gphttp/middleware/entrypoint_overlay_test.go
+++ b/internal/net/gphttp/middleware/entrypoint_overlay_test.go
@@ -1,0 +1,62 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildEntrypointRouteOverlayReturnsSentinelWhenNoPromotionOccurs(t *testing.T) {
+	t.Run("no_matching_entrypoint_middleware", func(t *testing.T) {
+		overlay, err := BuildEntrypointRouteOverlay(
+			"entrypoint",
+			[]map[string]any{{
+				"use": "response",
+			}},
+			"test-route",
+			map[string]OptionsRaw{
+				"redirectHTTP": {
+					"bypass": []string{"path /health"},
+				},
+			},
+		)
+
+		require.Nil(t, overlay)
+		require.ErrorIs(t, err, ErrNoEntrypointRouteOverlay)
+	})
+
+	t.Run("empty_route_middlewares", func(t *testing.T) {
+		overlay, err := BuildEntrypointRouteOverlay(
+			"entrypoint",
+			[]map[string]any{{
+				"use": "response",
+			}},
+			"test-route",
+			nil,
+		)
+
+		require.Nil(t, overlay)
+		require.ErrorIs(t, err, ErrNoEntrypointRouteOverlay)
+	})
+}
+
+func TestBuildEntrypointRouteOverlayPromotesRouteBypass(t *testing.T) {
+	overlay, err := BuildEntrypointRouteOverlay(
+		"entrypoint",
+		[]map[string]any{{
+			"use": "redirectHTTP",
+		}},
+		"test-route",
+		map[string]OptionsRaw{
+			"redirectHTTP": {
+				"bypass": []string{"path /health"},
+			},
+		},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, overlay)
+	require.NotNil(t, overlay.Middleware)
+	require.Contains(t, overlay.ConsumedBypass, "redirecthttp")
+	require.Contains(t, overlay.ConsumedMiddlewares, "redirecthttp")
+}

--- a/internal/net/gphttp/middleware/route_overlay_context.go
+++ b/internal/net/gphttp/middleware/route_overlay_context.go
@@ -1,0 +1,59 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	strutils "github.com/yusing/goutils/strings"
+)
+
+type routeOverlayConsumptionContextKey struct{}
+
+type routeOverlayConsumption struct {
+	bypass      map[string]struct{}
+	middlewares map[string]struct{}
+}
+
+var routeOverlayConsumptionKey routeOverlayConsumptionContextKey
+
+func WithConsumedRouteOverlays(
+	r *http.Request,
+	bypass map[string]struct{},
+	middlewares map[string]struct{},
+) *http.Request {
+	if len(bypass) == 0 && len(middlewares) == 0 {
+		return r
+	}
+	return r.WithContext(context.WithValue(r.Context(), routeOverlayConsumptionKey, routeOverlayConsumption{
+		bypass:      bypass,
+		middlewares: middlewares,
+	}))
+}
+
+func isRouteBypassPromoted(r *http.Request, middlewareName string) bool {
+	return routeOverlayConsumed(r, middlewareName, func(consumption routeOverlayConsumption) map[string]struct{} {
+		return consumption.bypass
+	})
+}
+
+func isRouteMiddlewareConsumed(r *http.Request, middlewareName string) bool {
+	return routeOverlayConsumed(r, middlewareName, func(consumption routeOverlayConsumption) map[string]struct{} {
+		return consumption.middlewares
+	})
+}
+
+func routeOverlayConsumed(
+	r *http.Request,
+	middlewareName string,
+	selectSet func(routeOverlayConsumption) map[string]struct{},
+) bool {
+	if r == nil {
+		return false
+	}
+	consumption, ok := r.Context().Value(routeOverlayConsumptionKey).(routeOverlayConsumption)
+	if !ok {
+		return false
+	}
+	_, ok = selectSet(consumption)[strutils.ToLowerNoSnake(middlewareName)]
+	return ok
+}

--- a/internal/net/gphttp/middleware/route_overlay_context_test.go
+++ b/internal/net/gphttp/middleware/route_overlay_context_test.go
@@ -1,0 +1,82 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/yusing/godoxy/internal/agentpool"
+	"github.com/yusing/godoxy/internal/homepage"
+	nettypes "github.com/yusing/godoxy/internal/net/types"
+	"github.com/yusing/godoxy/internal/route/routes"
+	"github.com/yusing/godoxy/internal/types"
+	"github.com/yusing/goutils/task"
+	expect "github.com/yusing/goutils/testing"
+)
+
+func TestWithConsumedRouteOverlaysPreservesExistingRequestContext(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://example.com", nil)
+	req = routes.WithRouteContext(req, fakeMiddlewareHTTPRoute{name: "test-route"})
+
+	req = WithConsumedRouteOverlays(req, map[string]struct{}{
+		"redirecthttp": {},
+	}, map[string]struct{}{
+		"oidc": {},
+	})
+
+	expect.Equal(t, routes.TryGetUpstreamName(req), "test-route")
+	expect.True(t, isRouteBypassPromoted(req, "redirectHTTP"))
+	expect.True(t, isRouteMiddlewareConsumed(req, "oidc"))
+	expect.False(t, isRouteBypassPromoted(req, "forwardauth"))
+	expect.False(t, isRouteMiddlewareConsumed(req, "forwardauth"))
+}
+
+func TestWithConsumedRouteOverlaysReturnsNewRequestWhenOverlayIsPresent(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://example.com", nil)
+	updated := WithConsumedRouteOverlays(req, map[string]struct{}{"redirecthttp": {}}, nil)
+
+	expect.NotEqual(t, req, updated)
+	expect.True(t, isRouteBypassPromoted(updated, "redirectHTTP"))
+	expect.False(t, isRouteBypassPromoted(req, "redirectHTTP"))
+}
+
+type fakeMiddlewareHTTPRoute struct {
+	name string
+}
+
+func (r fakeMiddlewareHTTPRoute) Key() string                                 { return r.name }
+func (r fakeMiddlewareHTTPRoute) Name() string                                { return r.name }
+func (r fakeMiddlewareHTTPRoute) Start(task.Parent) error                     { return nil }
+func (r fakeMiddlewareHTTPRoute) Task() *task.Task                            { return nil }
+func (r fakeMiddlewareHTTPRoute) Finish(any)                                  {}
+func (r fakeMiddlewareHTTPRoute) MarshalZerologObject(*zerolog.Event)         {}
+func (r fakeMiddlewareHTTPRoute) ProviderName() string                        { return "" }
+func (r fakeMiddlewareHTTPRoute) GetProvider() types.RouteProvider            { return nil }
+func (r fakeMiddlewareHTTPRoute) ListenURL() *nettypes.URL                    { return nil }
+func (r fakeMiddlewareHTTPRoute) TargetURL() *nettypes.URL                    { return nil }
+func (r fakeMiddlewareHTTPRoute) HealthMonitor() types.HealthMonitor          { return nil }
+func (r fakeMiddlewareHTTPRoute) SetHealthMonitor(types.HealthMonitor)        {}
+func (r fakeMiddlewareHTTPRoute) References() []string                        { return nil }
+func (r fakeMiddlewareHTTPRoute) ShouldExclude() bool                         { return false }
+func (r fakeMiddlewareHTTPRoute) Started() <-chan struct{}                    { return nil }
+func (r fakeMiddlewareHTTPRoute) IdlewatcherConfig() *types.IdlewatcherConfig { return nil }
+func (r fakeMiddlewareHTTPRoute) HealthCheckConfig() types.HealthCheckConfig {
+	return types.HealthCheckConfig{}
+}
+func (r fakeMiddlewareHTTPRoute) LoadBalanceConfig() *types.LoadBalancerConfig {
+	return nil
+}
+func (r fakeMiddlewareHTTPRoute) HomepageItem() homepage.Item                  { return homepage.Item{} }
+func (r fakeMiddlewareHTTPRoute) DisplayName() string                          { return r.name }
+func (r fakeMiddlewareHTTPRoute) ContainerInfo() *types.Container              { return nil }
+func (r fakeMiddlewareHTTPRoute) InboundMTLSProfileRef() string                { return "" }
+func (r fakeMiddlewareHTTPRoute) RouteMiddlewares() map[string]types.LabelMap  { return nil }
+func (r fakeMiddlewareHTTPRoute) GetAgent() *agentpool.Agent                   { return nil }
+func (r fakeMiddlewareHTTPRoute) IsDocker() bool                               { return false }
+func (r fakeMiddlewareHTTPRoute) IsAgent() bool                                { return false }
+func (r fakeMiddlewareHTTPRoute) UseLoadBalance() bool                         { return false }
+func (r fakeMiddlewareHTTPRoute) UseIdleWatcher() bool                         { return false }
+func (r fakeMiddlewareHTTPRoute) UseHealthCheck() bool                         { return false }
+func (r fakeMiddlewareHTTPRoute) UseAccessLog() bool                           { return false }
+func (r fakeMiddlewareHTTPRoute) ServeHTTP(http.ResponseWriter, *http.Request) {}

--- a/internal/net/gphttp/middleware/route_overlay_context_test.go
+++ b/internal/net/gphttp/middleware/route_overlay_context_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
 	"github.com/yusing/godoxy/internal/agentpool"
 	"github.com/yusing/godoxy/internal/homepage"
 	nettypes "github.com/yusing/godoxy/internal/net/types"
 	"github.com/yusing/godoxy/internal/route/routes"
 	"github.com/yusing/godoxy/internal/types"
 	"github.com/yusing/goutils/task"
-	expect "github.com/yusing/goutils/testing"
 )
 
 func TestWithConsumedRouteOverlaysPreservesExistingRequestContext(t *testing.T) {
@@ -25,20 +25,20 @@ func TestWithConsumedRouteOverlaysPreservesExistingRequestContext(t *testing.T) 
 		"oidc": {},
 	})
 
-	expect.Equal(t, routes.TryGetUpstreamName(req), "test-route")
-	expect.True(t, isRouteBypassPromoted(req, "redirectHTTP"))
-	expect.True(t, isRouteMiddlewareConsumed(req, "oidc"))
-	expect.False(t, isRouteBypassPromoted(req, "forwardauth"))
-	expect.False(t, isRouteMiddlewareConsumed(req, "forwardauth"))
+	require.Equal(t, "test-route", routes.TryGetUpstreamName(req))
+	require.True(t, isRouteBypassPromoted(req, "redirectHTTP"))
+	require.True(t, isRouteMiddlewareConsumed(req, "oidc"))
+	require.False(t, isRouteBypassPromoted(req, "forwardauth"))
+	require.False(t, isRouteMiddlewareConsumed(req, "forwardauth"))
 }
 
 func TestWithConsumedRouteOverlaysReturnsNewRequestWhenOverlayIsPresent(t *testing.T) {
 	req := httptest.NewRequest("GET", "http://example.com", nil)
 	updated := WithConsumedRouteOverlays(req, map[string]struct{}{"redirecthttp": {}}, nil)
 
-	expect.NotEqual(t, req, updated)
-	expect.True(t, isRouteBypassPromoted(updated, "redirectHTTP"))
-	expect.False(t, isRouteBypassPromoted(req, "redirectHTTP"))
+	require.NotEqual(t, req, updated)
+	require.True(t, isRouteBypassPromoted(updated, "redirectHTTP"))
+	require.False(t, isRouteBypassPromoted(req, "redirectHTTP"))
 }
 
 type fakeMiddlewareHTTPRoute struct {

--- a/internal/route/README.md
+++ b/internal/route/README.md
@@ -62,6 +62,17 @@ type Route struct {
 }
 ```
 
+`Middlewares` stores route-local raw middleware options, including Docker-label-derived maps such as:
+
+```yaml
+middlewares:
+  oidc:
+    bypass:
+      - path glob("/public/*")
+```
+
+For HTTP routes, this map is also the source used by entrypoint overlay promotion when a route-local `bypass` targets a middleware already configured on the entrypoint.
+
 `InboundMTLSProfile` references a named root-level inbound mTLS profile for this route.
 
 - It is only honored when no global `entrypoint.inbound_mtls_profile` is configured.

--- a/internal/route/provider/README.md
+++ b/internal/route/provider/README.md
@@ -196,6 +196,16 @@ labels:
       do: pass
 ```
 
+Route-local middleware bypass overlays use the existing per-route middleware label shape. For example, to add a bypass exception to an entrypoint-level `oidc` middleware for route `app1`:
+
+```yaml
+labels:
+  proxy.app1.middlewares.oidc.bypass: |
+    - path glob("/public/*")
+```
+
+If the entrypoint already has `use: oidc`, the route-local bypass is promoted into the effective entrypoint middleware for `app1`. If the entrypoint does not have `oidc`, this remains a normal route-local middleware definition.
+
 ### File Provider Configuration
 
 ```yaml

--- a/internal/route/provider/docker_test.go
+++ b/internal/route/provider/docker_test.go
@@ -135,6 +135,58 @@ func TestApplyLabel(t *testing.T) {
 	expect.Equal(t, a.HealthCheck.Interval, 10*time.Second)
 }
 
+func TestApplyLabelParsesMiddlewareBypassOverlay(t *testing.T) {
+	entries := makeRoutes(&container.Summary{
+		Names: dummyNames,
+		Labels: map[string]string{
+			D.LabelAliases:                    "a",
+			"proxy.a.scheme":                  "http",
+			"proxy.a.port":                    "4567",
+			"proxy.a.middlewares.oidc.bypass": "\n- path glob(/public/*)\n- path /health"[1:],
+		},
+	})
+
+	a, ok := entries["a"]
+	expect.True(t, ok)
+	expect.Equal(t, a.Middlewares, map[string]map[string]any{
+		"oidc": {
+			"bypass": "- path glob(/public/*)\n- path /health",
+		},
+	})
+}
+
+func TestApplyLabelWithMixedObjectAndFlatMiddlewareFields(t *testing.T) {
+	entries := makeRoutes(&container.Summary{
+		Names: dummyNames,
+		State: "running",
+		Labels: map[string]string{
+			"proxy.universal.port":                      "8080",
+			"proxy.universal.middlewares.oidc":          "allowed_groups: [everyone]",
+			"proxy.universal.middlewares.oidc.bypass":   "- path glob(/geheimenvan/*)",
+			"proxy.universal.middlewares.oidc.priority": "5",
+		},
+	})
+
+	universal, ok := entries["universal"]
+	expect.True(t, ok)
+	expect.Equal(t, universal.Port.Proxy, 8080)
+
+	oidc, ok := universal.Middlewares["oidc"]
+	expect.True(t, ok)
+
+	allowedGroups, ok := oidc["allowed_groups"].([]any)
+	expect.True(t, ok)
+	expect.Equal(t, allowedGroups, []any{"everyone"})
+
+	bypass, ok := oidc["bypass"].(string)
+	expect.True(t, ok)
+	expect.Equal(t, bypass, "- path glob(/geheimenvan/*)")
+
+	priority, ok := oidc["priority"].(string)
+	expect.True(t, ok)
+	expect.Equal(t, priority, "5")
+}
+
 func TestApplyLabelWithAlias(t *testing.T) {
 	entries := makeRoutes(&container.Summary{
 		Names: dummyNames,

--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"net/url"
 	"os"
@@ -135,7 +136,7 @@ func (r Routes) Contains(alias string) bool {
 }
 
 func (r *Route) RouteMiddlewares() map[string]types.LabelMap {
-	return r.Middlewares
+	return maps.Clone(r.Middlewares)
 }
 
 func (r *Route) Validate() error {

--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -134,6 +134,10 @@ func (r Routes) Contains(alias string) bool {
 	return ok
 }
 
+func (r *Route) RouteMiddlewares() map[string]types.LabelMap {
+	return r.Middlewares
+}
+
 func (r *Route) Validate() error {
 	// wait for alias to be set
 	if r.Alias == "" {

--- a/internal/route/route_test.go
+++ b/internal/route/route_test.go
@@ -206,6 +206,21 @@ func TestRouteApplyingHealthCheckDefaults(t *testing.T) {
 	require.Equal(t, 10*time.Second, hc.Timeout)
 }
 
+func TestRouteMiddlewaresReturnsClone(t *testing.T) {
+	original := types.LabelMap{"bypass": []string{"path /health"}}
+	r := &Route{
+		Middlewares: map[string]types.LabelMap{
+			"redirectHTTP": original,
+		},
+	}
+
+	got := r.RouteMiddlewares()
+	require.Equal(t, r.Middlewares, got)
+
+	delete(got, "redirectHTTP")
+	require.Contains(t, r.Middlewares, "redirectHTTP")
+}
+
 func TestRouteBindField(t *testing.T) {
 	t.Run("TCPSchemeWithCustomBind", func(t *testing.T) {
 		r := &Route{

--- a/internal/types/routes.go
+++ b/internal/types/routes.go
@@ -38,6 +38,7 @@ type (
 		DisplayName() string
 		ContainerInfo() *Container
 		InboundMTLSProfileRef() string
+		RouteMiddlewares() map[string]LabelMap
 
 		GetAgent() *agentpool.Agent
 

--- a/internal/types/routes.go
+++ b/internal/types/routes.go
@@ -38,6 +38,7 @@ type (
 		DisplayName() string
 		ContainerInfo() *Container
 		InboundMTLSProfileRef() string
+		// RouteMiddlewares returns a copy of the route middlewares
 		RouteMiddlewares() map[string]LabelMap
 
 		GetAgent() *agentpool.Agent


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Routes can promote route-local bypass rules into matching entrypoint middleware, layering route-specific bypasses onto existing entrypoint rules and avoiding duplicate evaluation.

* **Behavior Changes**
  * Entrypoint middleware updates now refresh per-route overlays at runtime; overlay compilation failures result in HTTP 500 (errors are not exposed verbatim).
  * Route middleware accessors now return safe clones.

* **Documentation**
  * Clarified promotion, consumption, merging and qualification semantics with examples.

* **Tests**
  * Added tests covering promotion, cache invalidation, consumption semantics, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->