### PR TITLE
Split autocert ACME work into a helper binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,9 @@ ENV BRANCH=${BRANCH}
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
   --mount=type=cache,target=/root/go/pkg/mod \
-  make ${MAKE_ARGS} docker=1 build
+  make ${MAKE_ARGS} docker=1 build && \
+  make autocert=1 build && \
+  mv /src/bin/godoxy-autocert /app/autocert
 
 # Stage 3: Final image
 FROM scratch
@@ -69,6 +71,7 @@ COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 
 # copy binary
 COPY --from=builder /app/run /app/run
+COPY --from=builder /app/autocert /app/autocert
 
 # copy certs
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ else ifeq ($(cli), 1)
 	NAME = godoxy-cli
 	PWD = ${shell pwd}/cmd/cli
 	PACKAGE = .
+else ifeq ($(autocert), 1)
+	NAME = godoxy-autocert
+	PWD = ${shell pwd}
+	PACKAGE = ./cmd/autocert
 else
 	NAME = godoxy
 	PWD = ${shell pwd}

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Have questions? Ask [ChatGPT](https://chatgpt.com/g/g-6825390374b481919ad482f2e4
   - Periodic notification of access summaries for number of allowed and blocked connections
 - **Advanced Automation**
   - Automatic SSL certificate management with Let's Encrypt ([using DNS-01 Challenge](https://docs.godoxy.dev/DNS-01-Providers))
+    - ACME obtain/renew work runs in an internal helper binary; config stays unchanged
   - Auto-configuration for Docker containers
   - Hot-reloading of configurations and container state changes
 - **Container Runtime Support**

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -6,6 +6,8 @@ Main entry point package for GoDoxy, a lightweight reverse proxy with WebUI for 
 
 This package contains the `main.go` entry point that initializes and starts the GoDoxy server. It coordinates the initialization of all core components including configuration loading, API server, authentication, and monitoring services.
 
+It also contains `cmd/autocert`, an internal oneshot helper binary spawned by the main process for ACME obtain/renew work.
+
 ## Architecture
 
 ```mermaid

--- a/cmd/autocert/README.md
+++ b/cmd/autocert/README.md
@@ -1,0 +1,8 @@
+# cmd/autocert
+
+Internal oneshot helper binary for ACME certificate lifecycle work.
+
+- Reads a config snapshot written by the main GoDoxy process
+- Performs one obtain/renew action, then exits
+- Reuses `internal/autocert.Provider` for ACME logic and error handling
+- Never serves public traffic directly

--- a/cmd/autocert/main.go
+++ b/cmd/autocert/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/goccy/go-yaml"
+	"github.com/rs/zerolog/log"
+	"github.com/yusing/godoxy/internal/autocert"
+	"github.com/yusing/godoxy/internal/dnsproviders"
+	"github.com/yusing/godoxy/internal/logging"
+	"github.com/yusing/godoxy/internal/logging/memlogger"
+	"github.com/yusing/godoxy/internal/serialization"
+)
+
+func main() {
+	var mode string
+	var configPath string
+	flag.StringVar(&mode, "mode", string(autocert.RunModeObtainIfMissing), "helper mode: obtain-if-missing or renew-all")
+	flag.StringVar(&configPath, "config", autocert.RuntimeConfigPath(), "autocert config snapshot path")
+	flag.Parse()
+
+	logging.InitLogger(os.Stderr, memlogger.GetMemLogger())
+	dnsproviders.InitProviders()
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		fail(err)
+	}
+
+	var cfg autocert.Config
+	if err := serialization.UnmarshalValidate(data, &cfg, yaml.Unmarshal); err != nil {
+		fail(err)
+	}
+
+	user, legoCfg, err := cfg.GetLegoConfig()
+	if err != nil {
+		fail(err)
+	}
+
+	provider, err := autocert.NewProvider(&cfg, user, legoCfg)
+	if err != nil {
+		fail(err)
+	}
+
+	var runErr error
+	switch autocert.RunMode(mode) {
+	case autocert.RunModeObtainIfMissing:
+		runErr = provider.ObtainCertIfNotExistsAll()
+	case autocert.RunModeRenewAll:
+		runErr = provider.ObtainCertAll()
+	default:
+		runErr = fmt.Errorf("unknown mode %q", mode)
+	}
+	if runErr != nil {
+		fail(runErr)
+	}
+	provider.PrintCertExpiriesAll()
+}
+
+func fail(err error) {
+	log.Error().Err(err).Msg("autocert helper failed")
+	os.Exit(1)
+}

--- a/internal/api/v1/cert/renew.go
+++ b/internal/api/v1/cert/renew.go
@@ -2,6 +2,7 @@ package certapi
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -32,6 +33,10 @@ func Renew(c *gin.Context) {
 
 	manager, err := websocket.NewManagerWithUpgrade(c)
 	if err != nil {
+		if !isWebSocketRequest(c.Request) {
+			renewWithoutWebSocket(c, provider)
+			return
+		}
 		c.Error(apitypes.InternalServerError(err, "failed to create websocket manager"))
 		return
 	}
@@ -69,4 +74,20 @@ func Renew(c *gin.Context) {
 	log.Info().Msg("cert force renewal requested")
 
 	provider.WaitRenewalDone(manager.Context())
+}
+
+func renewWithoutWebSocket(c *gin.Context, provider autocertctx.Provider) {
+	ok := provider.ForceExpiryAll()
+	if !ok {
+		c.JSON(http.StatusConflict, apitypes.Error("cert renewal already in progress"))
+		return
+	}
+	log.Info().Msg("cert force renewal requested")
+	provider.WaitRenewalDone(c.Request.Context())
+	c.JSON(http.StatusOK, apitypes.Success("cert renewal requested"))
+}
+
+func isWebSocketRequest(r *http.Request) bool {
+	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket") &&
+		strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
 }

--- a/internal/api/v1/cert/renew_test.go
+++ b/internal/api/v1/cert/renew_test.go
@@ -1,0 +1,39 @@
+package certapi
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	autocert "github.com/yusing/godoxy/internal/autocert/types"
+	"github.com/yusing/goutils/task"
+)
+
+type stubProvider struct {
+	started bool
+	waited  bool
+}
+
+func (p *stubProvider) GetCert(*tls.ClientHelloInfo) (*tls.Certificate, error) { return nil, nil }
+func (p *stubProvider) GetCertInfos() ([]autocert.CertInfo, error)             { return nil, nil }
+func (p *stubProvider) ScheduleRenewalAll(task.Parent)                         {}
+func (p *stubProvider) ObtainCertAll() error                                   { return nil }
+func (p *stubProvider) ForceExpiryAll() bool                                   { p.started = true; return true }
+func (p *stubProvider) WaitRenewalDone(context.Context) bool                   { p.waited = true; return true }
+
+func TestRenewWithoutWebsocketStillTriggersProvider(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	provider := &stubProvider{}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/cert/renew", nil)
+	c.Request = c.Request.WithContext(context.WithValue(c.Request.Context(), autocert.ContextKey{}, provider))
+
+	Renew(c)
+
+	require.True(t, provider.started)
+}

--- a/internal/autocert/README.md
+++ b/internal/autocert/README.md
@@ -8,6 +8,11 @@ Automated SSL certificate management using the ACME protocol (Let's Encrypt and 
 
 This package provides complete SSL certificate lifecycle management:
 
+This package is split between proxy-side certificate serving and helper-side ACME work:
+
+- **Proxy role:** file-backed certificate cache + scheduler in the main process
+- **Helper role:** spawned oneshot binary that performs obtain/renew work and exits
+
 - ACME account registration and management
 - Certificate issuance via DNS-01 challenge
 - Automatic renewal scheduling (1 month before expiry)

--- a/internal/autocert/cache.go
+++ b/internal/autocert/cache.go
@@ -1,0 +1,158 @@
+package autocert
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"os"
+	"sync"
+	"time"
+
+	autocerttypes "github.com/yusing/godoxy/internal/autocert/types"
+)
+
+type staticCertSource struct {
+	cert *tls.Certificate
+}
+
+func (s staticCertSource) getTLSCert() *tls.Certificate { return s.cert }
+
+type FileCache struct {
+	mu    sync.RWMutex
+	cfg   *Config
+	main  staticCertSource
+	extra []*FileCacheEntry
+	sni   sniMatcher
+}
+
+type FileCacheEntry struct {
+	cfg  ConfigExtra
+	cert staticCertSource
+}
+
+func NewFileCache(cfg *Config) (*FileCache, error) {
+	if cfg == nil {
+		cfg = new(Config)
+		_ = cfg.Validate()
+	}
+	clone := *cfg
+	clone.Extra = append([]ConfigExtra(nil), cfg.Extra...)
+	return &FileCache{cfg: &clone}, nil
+}
+
+func (c *FileCache) LoadAll() error {
+	if c == nil {
+		return ErrNoCertificates
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	mainCert, err := loadTLSCert(c.cfg.CertPath, c.cfg.KeyPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			c.main = staticCertSource{}
+			c.extra = nil
+			c.sni = sniMatcher{}
+			return ErrNoCertificates
+		}
+		return err
+	}
+
+	c.main = staticCertSource{cert: mainCert}
+	c.extra = c.extra[:0]
+	matcher := sniMatcher{}
+	matcher.addProvider(c.main)
+
+	for i := range c.cfg.Extra {
+		extraCfg := c.cfg.Extra[i]
+		cert, err := loadTLSCert(extraCfg.CertPath, extraCfg.KeyPath)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return err
+		}
+		entry := &FileCacheEntry{cfg: extraCfg, cert: staticCertSource{cert: cert}}
+		c.extra = append(c.extra, entry)
+		matcher.addProvider(entry.cert)
+	}
+	c.sni = matcher
+	return nil
+}
+
+func (c *FileCache) GetCert(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	cert := c.main.getTLSCert()
+	if cert == nil {
+		return nil, ErrNoCertificates
+	}
+	if hello == nil || hello.ServerName == "" {
+		return cert, nil
+	}
+	if src := c.sni.match(hello.ServerName); src != nil {
+		if matched := src.getTLSCert(); matched != nil {
+			return matched, nil
+		}
+	}
+	return cert, nil
+}
+
+func (c *FileCache) GetCertInfos() ([]autocerttypes.CertInfo, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	infos := make([]autocerttypes.CertInfo, 0, 1+len(c.extra))
+	for _, src := range append([]staticCertSource{c.main}, c.extraSources()...) {
+		cert := src.getTLSCert()
+		if cert == nil || cert.Leaf == nil {
+			continue
+		}
+		infos = append(infos, autocerttypes.CertInfo{
+			Subject:        cert.Leaf.Subject.CommonName,
+			Issuer:         cert.Leaf.Issuer.CommonName,
+			NotBefore:      cert.Leaf.NotBefore.Unix(),
+			NotAfter:       cert.Leaf.NotAfter.Unix(),
+			DNSNames:       append([]string(nil), cert.Leaf.DNSNames...),
+			EmailAddresses: append([]string(nil), cert.Leaf.EmailAddresses...),
+		})
+	}
+	if len(infos) == 0 {
+		return nil, ErrNoCertificates
+	}
+	return infos, nil
+}
+
+func (c *FileCache) ShouldRenewOn() time.Time {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if cert := c.main.getTLSCert(); cert != nil && cert.Leaf != nil {
+		return cert.Leaf.NotAfter.AddDate(0, -1, 0)
+	}
+	return time.Time{}
+}
+
+func (c *FileCache) extraSources() []staticCertSource {
+	out := make([]staticCertSource, 0, len(c.extra))
+	for _, entry := range c.extra {
+		out = append(out, entry.cert)
+	}
+	return out
+}
+
+func loadTLSCert(certPath, keyPath string) (*tls.Certificate, error) {
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(cert.Certificate) == 0 {
+		return nil, ErrNoCertificates
+	}
+	if leaf, err := x509.ParseCertificate(cert.Certificate[0]); err == nil {
+		cert.Leaf = leaf
+	}
+	return &cert, nil
+}
+
+var _ certSource = staticCertSource{}

--- a/internal/autocert/cache_test.go
+++ b/internal/autocert/cache_test.go
@@ -1,0 +1,99 @@
+package autocert
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeSelfSignedCertToPaths(t *testing.T, certPath, keyPath string, dnsNames []string) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	serial, err := rand.Int(rand.Reader, big.NewInt(1<<62))
+	require.NoError(t, err)
+
+	cn := ""
+	if len(dnsNames) > 0 {
+		cn = dnsNames[0]
+	}
+
+	tpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     dnsNames,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tpl, tpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o644))
+	require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}), 0o600))
+}
+
+func TestFileCacheGetCertBySNI(t *testing.T) {
+	mainDir := t.TempDir()
+	mainCert := filepath.Join(mainDir, "main.crt")
+	mainKey := filepath.Join(mainDir, "main.key")
+	writeSelfSignedCertToPaths(t, mainCert, mainKey, []string{"*.example.com"})
+
+	extraDir := t.TempDir()
+	extraCert := filepath.Join(extraDir, "extra.crt")
+	extraKey := filepath.Join(extraDir, "extra.key")
+	writeSelfSignedCertToPaths(t, extraCert, extraKey, []string{"foo.example.com"})
+
+	cfg := &Config{
+		Provider: ProviderLocal,
+		CertPath: mainCert,
+		KeyPath:  mainKey,
+		Extra:    []ConfigExtra{{CertPath: extraCert, KeyPath: extraKey}},
+	}
+
+	cache, err := NewFileCache(cfg)
+	require.NoError(t, err)
+	require.NoError(t, cache.LoadAll())
+
+	cert, err := cache.GetCert(&tls.ClientHelloInfo{ServerName: "foo.example.com"})
+	require.NoError(t, err)
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	require.NoError(t, err)
+	require.Contains(t, leaf.DNSNames, "foo.example.com")
+}
+
+func TestFileCacheGetCertInfos(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.crt")
+	keyPath := filepath.Join(dir, "cert.key")
+	writeSelfSignedCertToPaths(t, certPath, keyPath, []string{"api.example.com"})
+
+	cache, err := NewFileCache(&Config{Provider: ProviderLocal, CertPath: certPath, KeyPath: keyPath})
+	require.NoError(t, err)
+	require.NoError(t, cache.LoadAll())
+
+	infos, err := cache.GetCertInfos()
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+	require.Equal(t, "api.example.com", infos[0].Subject)
+}
+
+func TestFileCacheReturnsNoCertificatesWhenFilesMissing(t *testing.T) {
+	cache, err := NewFileCache(&Config{Provider: ProviderLocal, CertPath: "missing.crt", KeyPath: "missing.key"})
+	require.NoError(t, err)
+
+	err = cache.LoadAll()
+	require.ErrorIs(t, err, ErrNoCertificates)
+}

--- a/internal/autocert/config.go
+++ b/internal/autocert/config.go
@@ -150,7 +150,9 @@ func (cfg *Config) validate(seenPaths map[string]int) error {
 	}
 
 	if cfg.challengeProvider == nil {
-		cfg.challengeProvider, _ = Providers[ProviderLocal](nil)
+		if providerConstructor, ok := Providers[ProviderLocal]; ok {
+			cfg.challengeProvider, _ = providerConstructor(nil)
+		}
 	}
 
 	if len(cfg.Extra) > 0 {

--- a/internal/autocert/paths.go
+++ b/internal/autocert/paths.go
@@ -1,7 +1,39 @@
 package autocert
 
-const (
-	certBasePath    = "certs/"
-	CertFileDefault = certBasePath + "cert.crt"
-	KeyFileDefault  = certBasePath + "priv.key"
+import (
+	"os"
+	"path/filepath"
 )
+
+const (
+	certBasePath      = "certs/"
+	CertFileDefault   = certBasePath + "cert.crt"
+	KeyFileDefault    = certBasePath + "priv.key"
+	runtimeBasePath   = "data/autocert"
+	runtimeConfigName = "config.yml"
+	helperBinaryName  = "autocert"
+	helperBinaryEnv   = "GODOXY_AUTOCERT_BIN"
+)
+
+func RuntimeConfigPath() string {
+	return filepath.Join(runtimeBasePath, runtimeConfigName)
+}
+
+func DefaultHelperBinary() string {
+	if bin := os.Getenv(helperBinaryEnv); bin != "" {
+		return bin
+	}
+	exe, err := os.Executable()
+	if err == nil {
+		return filepath.Join(filepath.Dir(exe), helperBinaryName)
+	}
+	return helperBinaryName
+}
+
+// AutocertConfigSnapshotPath keeps the old local name for tests and callers
+// while RuntimeConfigPath is the helper-facing API.
+func AutocertConfigSnapshotPath() string { return RuntimeConfigPath() }
+
+// AutocertHelperBinary keeps the old local name for tests and callers while
+// DefaultHelperBinary is the helper-facing API.
+func AutocertHelperBinary() string { return DefaultHelperBinary() }

--- a/internal/autocert/provider.go
+++ b/internal/autocert/provider.go
@@ -106,8 +106,8 @@ func (p *Provider) GetCert(hello *tls.ClientHelloInfo) (*tls.Certificate, error)
 	if hello == nil || hello.ServerName == "" {
 		return tlsCert, nil
 	}
-	if prov := p.getSNIMatcher().match(hello.ServerName); prov != nil {
-		if cert := prov.getTLSCert(); cert != nil {
+	if src := p.getSNIMatcher().match(hello.ServerName); src != nil {
+		if cert := src.getTLSCert(); cert != nil {
 			return cert, nil
 		}
 	}

--- a/internal/autocert/runner.go
+++ b/internal/autocert/runner.go
@@ -1,0 +1,71 @@
+package autocert
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync/atomic"
+
+	"github.com/yusing/godoxy/internal/logging/memlogger"
+)
+
+type RunMode string
+
+const (
+	RunModeObtainIfMissing RunMode = "obtain-if-missing"
+	RunModeRenewAll        RunMode = "renew-all"
+)
+
+var ErrRunnerBusy = errors.New("autocert already running")
+
+type oneshotCmd interface {
+	Start() error
+	Wait() error
+}
+
+type cmdFactory interface {
+	New(ctx context.Context, mode RunMode, cfgPath string) oneshotCmd
+}
+
+type execFactory struct {
+	bin string
+}
+
+func (f execFactory) New(ctx context.Context, mode RunMode, cfgPath string) oneshotCmd {
+	cmd := exec.CommandContext(ctx, f.bin, "--mode", string(mode), "--config", cfgPath)
+	out := io.MultiWriter(os.Stderr, memlogger.GetMemLogger())
+	cmd.Stdout = out
+	cmd.Stderr = out
+	return cmd
+}
+
+type Runner struct {
+	factory cmdFactory
+	running atomic.Bool
+}
+
+func NewRunner(bin string) *Runner {
+	return &Runner{factory: execFactory{bin: bin}}
+}
+
+func (r *Runner) Run(ctx context.Context, mode RunMode, cfgPath string) error {
+	if r == nil {
+		return errors.New("autocert runner is nil")
+	}
+	if !r.running.CompareAndSwap(false, true) {
+		return ErrRunnerBusy
+	}
+	defer r.running.Store(false)
+
+	cmd := r.factory.New(ctx, mode, cfgPath)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start autocert helper %q: %w", mode, err)
+	}
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("run autocert helper %q: %w", mode, err)
+	}
+	return nil
+}

--- a/internal/autocert/runner_test.go
+++ b/internal/autocert/runner_test.go
@@ -1,0 +1,62 @@
+package autocert
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type stubCmd struct {
+	started bool
+	waitErr error
+}
+
+func (c *stubCmd) Start() error {
+	c.started = true
+	return nil
+}
+
+func (c *stubCmd) Wait() error { return c.waitErr }
+
+type stubFactory struct {
+	mode RunMode
+	cfg  string
+	cmd  *stubCmd
+}
+
+func (f *stubFactory) New(_ context.Context, mode RunMode, cfgPath string) oneshotCmd {
+	f.mode = mode
+	f.cfg = cfgPath
+	return f.cmd
+}
+
+func TestRunnerRunPassesModeAndSnapshot(t *testing.T) {
+	factory := &stubFactory{cmd: &stubCmd{}}
+	runner := &Runner{factory: factory}
+
+	err := runner.Run(t.Context(), RunModeRenewAll, "/tmp/autocert.yml")
+	require.NoError(t, err)
+	require.Equal(t, RunModeRenewAll, factory.mode)
+	require.Equal(t, "/tmp/autocert.yml", factory.cfg)
+	require.True(t, factory.cmd.started)
+}
+
+func TestRunnerRejectsConcurrentRuns(t *testing.T) {
+	factory := &stubFactory{cmd: &stubCmd{}}
+	runner := &Runner{factory: factory}
+	runner.running.Store(true)
+
+	err := runner.Run(t.Context(), RunModeRenewAll, "/tmp/autocert.yml")
+	require.ErrorIs(t, err, ErrRunnerBusy)
+	require.ErrorContains(t, err, "autocert already running")
+}
+
+func TestRunnerPropagatesWaitError(t *testing.T) {
+	factory := &stubFactory{cmd: &stubCmd{waitErr: errors.New("boom")}}
+	runner := &Runner{factory: factory}
+
+	err := runner.Run(t.Context(), RunModeObtainIfMissing, "/tmp/autocert.yml")
+	require.ErrorContains(t, err, "boom")
+}

--- a/internal/autocert/service.go
+++ b/internal/autocert/service.go
@@ -1,0 +1,307 @@
+package autocert
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/goccy/go-yaml"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	autocerttypes "github.com/yusing/godoxy/internal/autocert/types"
+	"github.com/yusing/godoxy/internal/notif"
+	"github.com/yusing/goutils/task"
+)
+
+type runOnce interface {
+	Run(ctx context.Context, mode RunMode, cfgPath string) error
+}
+
+type runnerFunc func(ctx context.Context, mode RunMode, cfgPath string) error
+
+func (f runnerFunc) Run(ctx context.Context, mode RunMode, cfgPath string) error {
+	return f(ctx, mode, cfgPath)
+}
+
+type Service struct {
+	cache        *FileCache
+	runner       runOnce
+	cfg          *Config
+	snapshotPath string
+
+	schedulerOnce sync.Once
+
+	mu      sync.Mutex
+	runDone chan struct{}
+	runErr  error
+	running atomic.Bool
+}
+
+func NewService(parent task.Parent, cfg *Config, helperBin string) (*Service, error) {
+	if cfg == nil {
+		cfg = new(Config)
+	}
+	clone := *cfg
+	clone.Extra = append([]ConfigExtra(nil), cfg.Extra...)
+	if err := clone.Validate(); err != nil {
+		return nil, err
+	}
+
+	cache, err := NewFileCache(&clone)
+	if err != nil {
+		return nil, err
+	}
+	if helperBin == "" {
+		helperBin = DefaultHelperBinary()
+	}
+	svc := &Service{
+		cache:        cache,
+		runner:       newRunner(helperBin),
+		cfg:          &clone,
+		snapshotPath: RuntimeConfigPath(),
+	}
+	if err := svc.writeSnapshot(); err != nil {
+		return nil, err
+	}
+
+	if svc.requiresHelper() {
+		if err := svc.runExclusive(parentContext(parent), RunModeObtainIfMissing); err != nil {
+			return nil, err
+		}
+	} else if err := svc.cache.LoadAll(); err != nil && !errors.Is(err, ErrNoCertificates) {
+		return nil, err
+	}
+
+	svc.PrintCertExpiriesAll()
+	if parent != nil {
+		svc.ScheduleRenewalAll(parent)
+	}
+	return svc, nil
+}
+
+func parentContext(parent task.Parent) context.Context {
+	if parent == nil {
+		return context.Background()
+	}
+	return parent.Context()
+}
+
+func (s *Service) requiresHelper() bool {
+	for _, cfg := range append([]*Config{s.cfg}, s.extraConfigs()...) {
+		if cfg.Provider != ProviderLocal && cfg.Provider != ProviderPseudo {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Service) extraConfigs() []*Config {
+	out := make([]*Config, 0, len(s.cfg.Extra))
+	for i := range s.cfg.Extra {
+		out = append(out, s.cfg.Extra[i].AsConfig())
+	}
+	return out
+}
+
+func (s *Service) writeSnapshot() error {
+	if err := os.MkdirAll(filepath.Dir(s.snapshotPath), 0o700); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(s.cfg)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.snapshotPath, data, 0o600)
+}
+
+func (s *Service) GetCert(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return s.cache.GetCert(hello)
+}
+
+func (s *Service) GetCertInfos() ([]autocerttypes.CertInfo, error) {
+	return s.cache.GetCertInfos()
+}
+
+func (s *Service) ScheduleRenewalAll(parent task.Parent) {
+	s.schedulerOnce.Do(func() {
+		if parent == nil || !s.requiresHelper() {
+			return
+		}
+		t := parent.Subtask("autocert-renew-scheduler", true)
+		go s.scheduleLoop(t)
+	})
+}
+
+func (s *Service) ObtainCertAll() error {
+	return s.runExclusive(context.Background(), RunModeRenewAll)
+}
+
+func (s *Service) ForceExpiryAll() bool {
+	done := make(chan struct{})
+	if !s.beginRun(done) {
+		return false
+	}
+	go func() {
+		err := s.runOnce(context.Background(), RunModeRenewAll)
+		s.finishRun(done, err)
+	}()
+	return true
+}
+
+func (s *Service) WaitRenewalDone(ctx context.Context) bool {
+	s.mu.Lock()
+	done := s.runDone
+	s.mu.Unlock()
+	if done == nil {
+		return false
+	}
+	select {
+	case <-done:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (s *Service) PrintCertExpiriesAll() {
+	infos, err := s.cache.GetCertInfos()
+	if err != nil {
+		return
+	}
+	for _, info := range infos {
+		log.Info().
+			Str("subject", info.Subject).
+			Time("not_after", time.Unix(info.NotAfter, 0)).
+			Msg("certificate expiry")
+	}
+}
+
+func (s *Service) runExclusive(ctx context.Context, mode RunMode) error {
+	done := make(chan struct{})
+	if !s.beginRun(done) {
+		return ErrRunnerBusy
+	}
+	err := s.runOnce(ctx, mode)
+	s.finishRun(done, err)
+	return err
+}
+
+func (s *Service) runOnce(ctx context.Context, mode RunMode) error {
+	if err := s.writeSnapshot(); err != nil {
+		return err
+	}
+	if s.requiresHelper() {
+		if err := s.runner.Run(ctx, mode, s.snapshotPath); err != nil {
+			return err
+		}
+	}
+	if err := s.cache.LoadAll(); err != nil {
+		if errors.Is(err, ErrNoCertificates) && !s.requiresHelper() {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *Service) beginRun(done chan struct{}) bool {
+	if !s.running.CompareAndSwap(false, true) {
+		return false
+	}
+	s.mu.Lock()
+	s.runDone = done
+	s.runErr = nil
+	s.mu.Unlock()
+	return true
+}
+
+func (s *Service) finishRun(done chan struct{}, err error) {
+	if err != nil {
+		log.Warn().Err(err).Msg("autocert helper failed")
+		notif.Notify(&notif.LogMessage{
+			Level: zerolog.ErrorLevel,
+			Title: "SSL certificate renewal failed",
+			Body:  notif.MessageBody(err.Error()),
+		})
+	}
+	s.mu.Lock()
+	s.runErr = err
+	close(done)
+	s.mu.Unlock()
+	s.running.Store(false)
+}
+
+func (s *Service) scheduleLoop(t *task.Task) {
+	defer t.Finish(nil)
+
+	for {
+		timer := time.NewTimer(s.nextRenewDelay())
+		select {
+		case <-t.Context().Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+
+		err := s.runExclusive(t.Context(), RunModeRenewAll)
+		if err == nil {
+			notif.Notify(&notif.LogMessage{
+				Level: zerolog.InfoLevel,
+				Title: "SSL certificate renewed",
+				Body:  notif.ListBody(s.cfg.Domains),
+			})
+			if s.nextRenewDelay() == 0 && !sleepOrDone(t.Context(), renewalCooldownDuration) {
+				return
+			}
+			continue
+		}
+		if !errors.Is(err, ErrRunnerBusy) {
+			log.Warn().Err(err).Msg("autocert scheduled renewal failed")
+		}
+		if !sleepOrDone(t.Context(), renewalCooldownDuration) {
+			return
+		}
+	}
+}
+
+func sleepOrDone(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func (s *Service) nextRenewDelay() time.Duration {
+	infos, err := s.cache.GetCertInfos()
+	if err != nil || len(infos) == 0 {
+		return time.Minute
+	}
+
+	var next time.Time
+	for _, info := range infos {
+		renewAt := time.Unix(info.NotAfter, 0).AddDate(0, -1, 0)
+		if next.IsZero() || renewAt.Before(next) {
+			next = renewAt
+		}
+	}
+	delay := time.Until(next)
+	if delay < 0 {
+		return 0
+	}
+	return delay
+}
+
+var _ autocerttypes.Provider = (*Service)(nil)
+
+var newRunner = func(bin string) runOnce {
+	return NewRunner(bin)
+}

--- a/internal/autocert/service_test.go
+++ b/internal/autocert/service_test.go
@@ -1,0 +1,140 @@
+package autocert
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-acme/lego/v4/challenge"
+	"github.com/stretchr/testify/require"
+	strutils "github.com/yusing/goutils/strings"
+	"github.com/yusing/goutils/task"
+)
+
+type stubRunner struct {
+	mu    sync.Mutex
+	modes []RunMode
+	err   error
+	block chan struct{}
+}
+
+func (r *stubRunner) Run(_ context.Context, mode RunMode, _ string) error {
+	r.mu.Lock()
+	r.modes = append(r.modes, mode)
+	block := r.block
+	err := r.err
+	r.mu.Unlock()
+	if block != nil {
+		<-block
+	}
+	return err
+}
+
+func (r *stubRunner) calls() []RunMode {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]RunMode(nil), r.modes...)
+}
+
+func newTestService(t *testing.T, runner runOnce) *Service {
+	t.Helper()
+	cache, err := NewFileCache(&Config{Provider: ProviderLocal})
+	require.NoError(t, err)
+	return &Service{
+		cache:        cache,
+		runner:       runner,
+		cfg:          &Config{Provider: ProviderCustom},
+		snapshotPath: filepath.Join(t.TempDir(), "config.yml"),
+	}
+}
+
+func TestServiceForceExpiryRunsRenewAll(t *testing.T) {
+	runner := &stubRunner{}
+	svc := newTestService(t, runner)
+
+	ok := svc.ForceExpiryAll()
+	require.True(t, ok)
+	require.Eventually(t, func() bool { return len(runner.calls()) == 1 }, time.Second, 25*time.Millisecond)
+	require.Equal(t, []RunMode{RunModeRenewAll}, runner.calls())
+}
+
+func TestServiceRejectsSecondForceExpiryWhileRunning(t *testing.T) {
+	started := make(chan struct{})
+	finish := make(chan struct{})
+	runner := runnerFunc(func(_ context.Context, mode RunMode, _ string) error {
+		require.Equal(t, RunModeRenewAll, mode)
+		close(started)
+		<-finish
+		return nil
+	})
+	svc := newTestService(t, runner)
+
+	require.True(t, svc.ForceExpiryAll())
+	<-started
+	require.False(t, svc.ForceExpiryAll())
+	close(finish)
+}
+
+func TestServiceWaitRenewalDoneTracksCurrentRun(t *testing.T) {
+	finish := make(chan struct{})
+	runner := runnerFunc(func(_ context.Context, _ RunMode, _ string) error {
+		<-finish
+		return nil
+	})
+	svc := newTestService(t, runner)
+
+	require.True(t, svc.ForceExpiryAll())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		close(finish)
+	}()
+	require.True(t, svc.WaitRenewalDone(t.Context()))
+}
+
+func TestNewServiceRunsInitialObtainIfMissingAndLoadsCache(t *testing.T) {
+	prev := newRunner
+	defer func() { newRunner = prev }()
+	t.Cleanup(func() { _ = os.RemoveAll(runtimeBasePath) })
+	const providerName = "helper-test"
+	prevProvider, hadProvider := Providers[providerName]
+	Providers[providerName] = func(map[string]strutils.Redacted) (challenge.Provider, error) {
+		return nil, nil
+	}
+	t.Cleanup(func() {
+		if hadProvider {
+			Providers[providerName] = prevProvider
+			return
+		}
+		delete(Providers, providerName)
+	})
+
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.crt")
+	keyPath := filepath.Join(dir, "cert.key")
+	runner := runnerFunc(func(_ context.Context, mode RunMode, _ string) error {
+		require.Equal(t, RunModeObtainIfMissing, mode)
+		writeSelfSignedCertToPaths(t, certPath, keyPath, []string{"api.example.com"})
+		return nil
+	})
+	newRunner = func(string) runOnce { return runner }
+
+	root := task.RootTask("test", false)
+	t.Cleanup(func() { root.Finish(nil) })
+
+	svc, err := NewService(root, &Config{
+		Provider: providerName,
+		Email:    "test@example.com",
+		Domains:  []string{"api.example.com"},
+		CertPath: certPath,
+		KeyPath:  keyPath,
+	}, "/tmp/helper")
+	require.NoError(t, err)
+
+	infos, err := svc.GetCertInfos()
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+	require.Equal(t, "api.example.com", infos[0].Subject)
+}

--- a/internal/autocert/sni_matcher.go
+++ b/internal/autocert/sni_matcher.go
@@ -1,21 +1,26 @@
 package autocert
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"strings"
 )
 
+type certSource interface {
+	getTLSCert() *tls.Certificate
+}
+
 type sniMatcher struct {
-	exact map[string]*Provider
+	exact map[string]certSource
 	root  sniTreeNode
 }
 
 type sniTreeNode struct {
 	children map[string]*sniTreeNode
-	wildcard *Provider
+	wildcard certSource
 }
 
-func (m *sniMatcher) match(serverName string) *Provider {
+func (m *sniMatcher) match(serverName string) certSource {
 	if m == nil {
 		return nil
 	}
@@ -31,11 +36,11 @@ func (m *sniMatcher) match(serverName string) *Provider {
 	return m.matchSuffixTree(serverName)
 }
 
-func (m *sniMatcher) matchSuffixTree(serverName string) *Provider {
+func (m *sniMatcher) matchSuffixTree(serverName string) certSource {
 	n := &m.root
 	labels := strings.Split(serverName, ".")
 
-	var best *Provider
+	var best certSource
 	for i := len(labels) - 1; i >= 0; i-- {
 		if n.children == nil {
 			break
@@ -61,7 +66,7 @@ func normalizeServerName(s string) string {
 	return strings.ToLower(s)
 }
 
-func (m *sniMatcher) addProvider(p *Provider) {
+func (m *sniMatcher) addProvider(p certSource) {
 	if p == nil {
 		return
 	}
@@ -98,19 +103,19 @@ func (m *sniMatcher) addProvider(p *Provider) {
 	}
 }
 
-func (m *sniMatcher) insertExact(name string, p *Provider) {
+func (m *sniMatcher) insertExact(name string, p certSource) {
 	if name == "" || p == nil {
 		return
 	}
 	if m.exact == nil {
-		m.exact = make(map[string]*Provider)
+		m.exact = make(map[string]certSource)
 	}
 	if _, exists := m.exact[name]; !exists {
 		m.exact[name] = p
 	}
 }
 
-func (m *sniMatcher) insertWildcardSuffix(suffix string, p *Provider) {
+func (m *sniMatcher) insertWildcardSuffix(suffix string, p certSource) {
 	if suffix == "" || p == nil {
 		return
 	}

--- a/internal/config/autocert_state_test.go
+++ b/internal/config/autocert_state_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"context"
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yusing/godoxy/internal/autocert"
+	autocerttypes "github.com/yusing/godoxy/internal/autocert/types"
+	"github.com/yusing/goutils/task"
+)
+
+type stubAutoCertProvider struct{}
+
+func (p *stubAutoCertProvider) GetCert(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return nil, nil
+}
+func (p *stubAutoCertProvider) GetCertInfos() ([]autocerttypes.CertInfo, error) { return nil, nil }
+func (p *stubAutoCertProvider) ScheduleRenewalAll(task.Parent)                  {}
+func (p *stubAutoCertProvider) ObtainCertAll() error                            { return nil }
+func (p *stubAutoCertProvider) ForceExpiryAll() bool                            { return true }
+func (p *stubAutoCertProvider) WaitRenewalDone(context.Context) bool            { return true }
+
+func TestInitAutoCertUsesServiceFactory(t *testing.T) {
+	prev := newAutoCertService
+	defer func() { newAutoCertService = prev }()
+
+	called := false
+	newAutoCertService = func(parent task.Parent, cfg *autocert.Config) (autocerttypes.Provider, error) {
+		called = true
+		require.NotNil(t, parent)
+		require.Equal(t, autocert.ProviderLocal, cfg.Provider)
+		return &stubAutoCertProvider{}, nil
+	}
+
+	state := NewState().(*state)
+	state.AutoCert = &autocert.Config{Provider: autocert.ProviderLocal}
+
+	err := state.initAutoCert()
+	require.NoError(t, err)
+	require.True(t, called)
+	require.NotNil(t, state.autocertProvider)
+}

--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -47,7 +47,7 @@ type state struct {
 	config.Config
 
 	providers        *xsync.Map[string, types.RouteProvider]
-	autocertProvider *autocert.Provider
+	autocertProvider autocertctx.Provider
 	entrypoint       *entrypoint.Entrypoint
 
 	task *task.Task
@@ -314,7 +314,7 @@ func (state *state) initEntrypoint() error {
 	}
 
 	if state.autocertProvider != nil {
-		if domain := getAutoCertDefaultDomain(state.autocertProvider); domain != "" {
+		if domain := getAutoCertDefaultDomain(state.AutoCert); domain != "" {
 			state.entrypoint.ShortLinkMatcher().SetDefaultDomainSuffix("." + domain)
 		}
 	}
@@ -328,11 +328,14 @@ func (state *state) initEntrypoint() error {
 	return errs.Error()
 }
 
-func getAutoCertDefaultDomain(p *autocert.Provider) string {
-	if p == nil {
+func getAutoCertDefaultDomain(cfg *autocert.Config) string {
+	if cfg == nil {
 		return ""
 	}
-	cert, err := tls.LoadX509KeyPair(p.GetCertPath(), p.GetKeyPath())
+	clone := *cfg
+	clone.Extra = nil
+	_ = clone.Validate()
+	cert, err := tls.LoadX509KeyPair(clone.CertPath, clone.KeyPath)
 	if err != nil || len(cert.Certificate) == 0 {
 		return ""
 	}
@@ -378,28 +381,21 @@ func (state *state) initAutoCert() error {
 	if autocertCfg == nil {
 		autocertCfg = new(autocert.Config)
 		_ = autocertCfg.Validate()
+		state.AutoCert = autocertCfg
 	}
 
-	user, legoCfg, err := autocertCfg.GetLegoConfig()
+	p, err := newAutoCertService(state.task, autocertCfg)
 	if err != nil {
 		return err
 	}
-
-	p, err := autocert.NewProvider(autocertCfg, user, legoCfg)
-	if err != nil {
-		return err
-	}
-
-	if err := p.ObtainCertIfNotExistsAll(); err != nil {
-		return err
-	}
-
-	p.ScheduleRenewalAll(state.task)
-	p.PrintCertExpiriesAll()
 
 	state.autocertProvider = p
 	autocertctx.SetCtx(state.task, p)
 	return nil
+}
+
+var newAutoCertService = func(parent task.Parent, cfg *autocert.Config) (autocertctx.Provider, error) {
+	return autocert.NewService(parent, cfg, autocert.DefaultHelperBinary())
 }
 
 func (state *state) initProxmox() error {


### PR DESCRIPTION
## Summary
- move autocert obtain/renew ACME work into a spawned helper binary
- keep TLS handshakes and renewal coordination inside main proxy process
- add cache/runner/service seams plus packaging and regression coverage

## Test Plan
- [x] `go test -ldflags="-checklinkname=0" ./cmd/autocert ./internal/autocert ./internal/autocert/provider_test -count=1`
- [x] `go test -ldflags="-checklinkname=0" ./internal/config ./internal/api ./internal/api/v1/cert ./internal/entrypoint -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Certificate obtain and renewal operations now run in a dedicated helper binary for improved isolation and reliability.
  * Added support for triggering certificate renewal via non-WebSocket API requests.

* **Improvements**
  * Enhanced certificate caching and lifecycle management system.
  * Improved certificate provider configuration validation.

* **Documentation**
  * Updated documentation to describe the two-part certificate management architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->