### PR TITLE
Feat/tls passthrough

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,10 +93,13 @@ ifeq ($(docker), 1)
 	POST_BUILD += mkdir -p /app && mv ${BIN_PATH} /app/run;
 endif
 
-.PHONY: debug
+.PHONY: debug test tcp-echo-test
 
 test:
 	CGO_ENABLED=1 go test -v -race ${BUILD_FLAGS} ./internal/...
+
+tcp-echo-test:
+	bun --bun scripts/tcp_echo_test.ts
 
 docker-build-test:
 	docker build -t ${TEST_REGISTRY}/godoxy .

--- a/cmd/tcp_echo_server/Dockerfile
+++ b/cmd/tcp_echo_server/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.26.2-alpine AS builder
+
+HEALTHCHECK NONE
+
+WORKDIR /src
+
+COPY main.go ./
+
+RUN go build -o tcp_echo_server main.go
+
+FROM scratch
+
+COPY --from=builder /src/tcp_echo_server /app/run
+
+USER 1001:1001
+
+EXPOSE 9000/tcp 9443/tcp
+
+CMD ["/app/run"]

--- a/cmd/tcp_echo_server/README.md
+++ b/cmd/tcp_echo_server/README.md
@@ -1,0 +1,21 @@
+# cmd/tcp_echo_server
+
+Minimal TCP echo service for development testing of SNI TCP routing.
+
+## Listeners
+
+- `:9000` — plaintext TCP echo.
+- `:9443` — TLS echo using an ephemeral self-signed ECDSA certificate generated at process start.
+
+## Dev compose routes
+
+`dev.compose.yml` wires this service with two aliases for issue #230 testing:
+
+- `tcp-echo-passthrough` routes `443:9443` with `scheme: tcp` for TLS passthrough (for example, SNI `tcp-echo-passthrough.my.app` when `.my.app` is a match domain).
+- `tcp-echo-termination` routes `443:9000` with `scheme: tcp` and `tls_termination: true` for TLS termination before plaintext upstream echo (for example, SNI `tcp-echo-termination.my.app` when `.my.app` is a match domain).
+
+Health checks are disabled because this service speaks raw TCP, not HTTP.
+
+## Make test recipe
+
+`make tcp-echo-test` starts the `tcp_echo_server` service from `dev.compose.yml`, then connects to `localhost:443` with SNI for both Docker-label routes. This tests GoDoxy TLS passthrough and TLS termination routing, not direct fixture ports.

--- a/cmd/tcp_echo_server/main.go
+++ b/cmd/tcp_echo_server/main.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"io"
+	"log"
+	"math/big"
+	"net"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	tcpAddr = ":9000"
+	tlsAddr = ":9443"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	cert, err := newSelfSignedCert()
+	if err != nil {
+		log.Fatalf("generate tls cert: %v", err)
+	}
+
+	listeners := []struct {
+		name string
+		ln   net.Listener
+	}{
+		{name: "tcp", ln: mustListen("tcp", tcpAddr)},
+		{name: "tls", ln: mustListenTLS(tlsAddr, cert)},
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(listeners))
+
+	for _, listener := range listeners {
+		wg.Go(func() {
+			errCh <- serve(ctx, listener.name, listener.ln)
+		})
+	}
+
+	select {
+	case <-ctx.Done():
+	case err := <-errCh:
+		if err != nil {
+			log.Printf("server error: %v", err)
+		}
+		stop()
+	}
+
+	for _, listener := range listeners {
+		_ = listener.ln.Close()
+	}
+	wg.Wait()
+}
+
+func mustListen(network, addr string) net.Listener {
+	ln, err := net.Listen(network, addr)
+	if err != nil {
+		log.Fatalf("listen %s %s: %v", network, addr, err)
+	}
+	log.Printf("tcp echo listening on %s", addr)
+	return ln
+}
+
+func mustListenTLS(addr string, cert tls.Certificate) net.Listener {
+	ln, err := tls.Listen("tcp", addr, &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	})
+	if err != nil {
+		log.Fatalf("listen tls %s: %v", addr, err)
+	}
+	log.Printf("tls echo listening on %s", addr)
+	return ln
+}
+
+func serve(ctx context.Context, name string, ln net.Listener) error {
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) || ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+		go echo(name, conn)
+	}
+}
+
+func echo(name string, conn net.Conn) {
+	defer conn.Close()
+	log.Printf("%s echo connection from %s", name, conn.RemoteAddr())
+	if _, err := io.Copy(conn, conn); err != nil && !errors.Is(err, net.ErrClosed) {
+		log.Printf("%s echo error from %s: %v", name, conn.RemoteAddr(), err)
+	}
+}
+
+func newSelfSignedCert() (tls.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, serialLimit)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: "godoxy tcp echo dev cert",
+		},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost", "tcp-echo-passthrough.my.app"},
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyBytes, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+	return tls.X509KeyPair(certPEM, keyPEM)
+}

--- a/config.example.yml
+++ b/config.example.yml
@@ -162,6 +162,20 @@ providers:
 # configuration (for example, see providers.example.yml). UDP relay is not
 # supported yet.
 
+# TCP routes on HTTPS_ADDR match TLS SNI by alias, same as HTTP routes.
+# Default is passthrough; set tls_termination to proxy plaintext upstream.
+#
+# routes:
+#   site2:
+#     scheme: tcp
+#     host: 100.64.0.10
+#     port: 443:443
+#   mqtt:
+#     scheme: tcp
+#     host: 100.64.0.20
+#     port: 443:1883
+#     tls_termination: true
+
 # Match domains
 # See https://docs.godoxy.dev/Certificates-and-domain-matching
 #

--- a/dev.compose.yml
+++ b/dev.compose.yml
@@ -95,6 +95,21 @@ services:
     labels:
       proxy.#1.scheme: h2c
       proxy.#1.port: 80
+  tcp_echo_server: # issue #230 TLS passthrough / termination
+    build:
+      context: cmd/tcp_echo_server
+      dockerfile: Dockerfile
+    container_name: tcp_echo_test
+    restart: unless-stopped
+    labels:
+      proxy.aliases: tcp-echo-passthrough,tcp-echo-termination
+      proxy.#1.scheme: tcp
+      proxy.#1.port: 443:9443
+      proxy.#1.healthcheck.disable: true
+      proxy.#2.scheme: tcp
+      proxy.#2.port: 443:9000
+      proxy.#2.tls_termination: true
+      proxy.#2.healthcheck.disable: true
   bench: # returns 4096 bytes of random data
     <<: *benchmark
     build:

--- a/internal/entrypoint/entrypoint.go
+++ b/internal/entrypoint/entrypoint.go
@@ -24,6 +24,7 @@ type HTTPRoutes interface {
 }
 
 type findRouteFunc func(HTTPRoutes, string) types.HTTPRoute
+type findRouteKeyFunc func(string, func(string) bool) (string, bool)
 
 type Entrypoint struct {
 	task *task.Task
@@ -34,6 +35,7 @@ type Entrypoint struct {
 	notFoundHandler  http.Handler
 	accessLogger     accesslog.AccessLogger
 	findRouteFunc    findRouteFunc
+	findRouteKeyFunc findRouteKeyFunc
 	shortLinkMatcher *ShortLinkMatcher
 
 	streamRoutes   *pool.Pool[types.StreamRoute]
@@ -43,6 +45,8 @@ type Entrypoint struct {
 	httpPoolDisableLog atomic.Bool
 
 	servers *xsync.Map[string, *httpServer] // listen addr -> server
+
+	sni *sniRouter
 
 	inboundMTLSProfiles map[string]*x509.CertPool
 }
@@ -69,12 +73,14 @@ func NewEntrypoint(parent task.Parent, cfg *Config) *Entrypoint {
 		task:                parent.Subtask("entrypoint", false),
 		cfg:                 cfg,
 		findRouteFunc:       findRouteAnyDomain,
+		findRouteKeyFunc:    findRouteKeyAnyDomain,
 		shortLinkMatcher:    newShortLinkMatcher(),
 		streamRoutes:        pool.New[types.StreamRoute]("stream_routes", "stream_routes"),
 		excludedRoutes:      pool.New[types.Route]("excluded_routes", "excluded_routes"),
 		servers:             xsync.NewMap[string, *httpServer](),
 		inboundMTLSProfiles: make(map[string]*x509.CertPool),
 	}
+	ep.sni = newSNIRouter(ep)
 	return ep
 }
 
@@ -120,6 +126,7 @@ func (ep *Entrypoint) GetServer(addr string) (HTTPServer, bool) {
 func (ep *Entrypoint) SetFindRouteDomains(domains []string) {
 	if len(domains) == 0 {
 		ep.findRouteFunc = findRouteAnyDomain
+		ep.findRouteKeyFunc = findRouteKeyAnyDomain
 	} else {
 		for i, domain := range domains {
 			if !strings.HasPrefix(domain, ".") {
@@ -127,6 +134,7 @@ func (ep *Entrypoint) SetFindRouteDomains(domains []string) {
 			}
 		}
 		ep.findRouteFunc = findRouteByDomains(domains)
+		ep.findRouteKeyFunc = findRouteKeyByDomains(domains)
 	}
 }
 
@@ -199,6 +207,23 @@ func findRouteAnyDomain(routes HTTPRoutes, host string) types.HTTPRoute {
 	return nil
 }
 
+func findRouteKeyAnyDomain(host string, exists func(string) bool) (string, bool) {
+	before, _, ok := strings.Cut(host, ".")
+	if ok && exists(before) {
+		return before, true
+	}
+	if exists(host) {
+		return host, true
+	}
+	// try striping the trailing :port from the host
+	if before, _, ok := strings.Cut(host, ":"); ok {
+		if exists(before) {
+			return before, true
+		}
+	}
+	return "", false
+}
+
 func findRouteByDomains(domains []string) func(routes HTTPRoutes, host string) types.HTTPRoute {
 	return func(routes HTTPRoutes, host string) types.HTTPRoute {
 		host, _, _ = strings.Cut(host, ":") // strip the trailing :port
@@ -215,5 +240,21 @@ func findRouteByDomains(domains []string) func(routes HTTPRoutes, host string) t
 			return r
 		}
 		return nil
+	}
+}
+
+func findRouteKeyByDomains(domains []string) findRouteKeyFunc {
+	return func(host string, exists func(string) bool) (string, bool) {
+		host, _, _ = strings.Cut(host, ":") // strip the trailing :port
+		for _, domain := range domains {
+			if target, ok := strings.CutSuffix(host, domain); ok && exists(target) {
+				return target, true
+			}
+		}
+
+		if exists(host) {
+			return host, true
+		}
+		return "", false
 	}
 }

--- a/internal/entrypoint/entrypoint_test.go
+++ b/internal/entrypoint/entrypoint_test.go
@@ -1,6 +1,7 @@
 package entrypoint_test
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +15,8 @@ import (
 	expect "github.com/yusing/goutils/testing"
 )
 
+const testHTTPRouteListenPort = 18080
+
 func addRoute(t *testing.T, alias string) {
 	t.Helper()
 
@@ -24,7 +27,7 @@ func addRoute(t *testing.T, alias string) {
 		Alias:  alias,
 		Scheme: routeTypes.SchemeHTTP,
 		Port: route.Port{
-			Listening: 1000,
+			Listening: testHTTPRouteListenPort,
 			Proxy:     8080,
 		},
 		HealthCheck: types.HealthCheckConfig{
@@ -43,7 +46,7 @@ func addRoute(t *testing.T, alias string) {
 func run(t *testing.T, ep *Entrypoint, match []string, noMatch []string) {
 	t.Helper()
 
-	server, ok := ep.GetServer(":1000")
+	server, ok := ep.GetServer(":" + strconv.Itoa(testHTTPRouteListenPort))
 	require.True(t, ok, "server not found")
 	require.NotNil(t, server)
 

--- a/internal/entrypoint/http_server.go
+++ b/internal/entrypoint/http_server.go
@@ -85,7 +85,7 @@ func (srv *httpServer) listen(addr string, proto HTTPProto, listener net.Listene
 	supportProxyProtocol := srv.ep.cfg.SupportProxyProtocol
 	certProvider := autocert.FromCtx(srv.ep.task.Context())
 	var sniListener net.Listener
-	if proto == HTTPProtoHTTPS && listener == nil && certProvider != nil {
+	if proto == HTTPProtoHTTPS && listener == nil {
 		var err error
 		sniListener, err = srv.ep.sni.Listen(addr)
 		if err != nil {

--- a/internal/entrypoint/http_server.go
+++ b/internal/entrypoint/http_server.go
@@ -81,11 +81,24 @@ func (srv *httpServer) listen(addr string, proto HTTPProto, listener net.Listene
 		return errors.New("server already started")
 	}
 
+	aclCfg := acl.FromCtx(srv.ep.task.Context())
+	supportProxyProtocol := srv.ep.cfg.SupportProxyProtocol
+	certProvider := autocert.FromCtx(srv.ep.task.Context())
+	if proto == HTTPProtoHTTPS && listener == nil && certProvider != nil {
+		sniListener, err := srv.ep.sni.Listen(addr)
+		if err != nil {
+			return err
+		}
+		listener = sniListener
+		aclCfg = nil
+		supportProxyProtocol = false
+	}
+
 	opts := server.Options{
 		Name:                 addr,
 		Handler:              srv,
-		ACL:                  acl.FromCtx(srv.ep.task.Context()),
-		SupportProxyProtocol: srv.ep.cfg.SupportProxyProtocol,
+		ACL:                  aclCfg,
+		SupportProxyProtocol: supportProxyProtocol,
 	}
 
 	switch proto {
@@ -95,7 +108,7 @@ func (srv *httpServer) listen(addr string, proto HTTPProto, listener net.Listene
 	case HTTPProtoHTTPS:
 		opts.HTTPSAddr = addr
 		opts.HTTPSListener = listener
-		opts.CertProvider = autocert.FromCtx(srv.ep.task.Context())
+		opts.CertProvider = certProvider
 		opts.TLSConfigMutator = srv.mutateServerTLSConfig
 	}
 

--- a/internal/entrypoint/http_server.go
+++ b/internal/entrypoint/http_server.go
@@ -84,8 +84,10 @@ func (srv *httpServer) listen(addr string, proto HTTPProto, listener net.Listene
 	aclCfg := acl.FromCtx(srv.ep.task.Context())
 	supportProxyProtocol := srv.ep.cfg.SupportProxyProtocol
 	certProvider := autocert.FromCtx(srv.ep.task.Context())
+	var sniListener net.Listener
 	if proto == HTTPProtoHTTPS && listener == nil && certProvider != nil {
-		sniListener, err := srv.ep.sni.Listen(addr)
+		var err error
+		sniListener, err = srv.ep.sni.Listen(addr)
 		if err != nil {
 			return err
 		}
@@ -115,6 +117,10 @@ func (srv *httpServer) listen(addr string, proto HTTPProto, listener net.Listene
 	task := srv.ep.task.Subtask("http_server", false)
 	_, err := server.StartServer(task, opts)
 	if err != nil {
+		task.Finish(err)
+		if sniListener != nil {
+			err = errors.Join(err, sniListener.Close())
+		}
 		return err
 	}
 	srv.stopFunc = task.FinishAndWait

--- a/internal/entrypoint/routes.go
+++ b/internal/entrypoint/routes.go
@@ -64,6 +64,19 @@ func (ep *Entrypoint) StartAddRoute(r types.Route) error {
 			ep.shortLinkMatcher.DelRoute(r.Key())
 		})
 	case types.StreamRoute:
+		if asSNIRoute(r) {
+			if err := ep.sni.AddRoute(r); err != nil {
+				return err
+			}
+			ep.streamRoutes.Add(r)
+			r.Task().OnCancel("remove_sni_route", func() {
+				ep.sni.DelRoute(r)
+				_ = r.Stream().Close()
+				ep.streamRoutes.Del(r)
+			})
+			return nil
+		}
+
 		err := r.ListenAndServe(r.Task().Context(), nil, nil)
 		if err != nil {
 			return err

--- a/internal/entrypoint/sni_passthrough.go
+++ b/internal/entrypoint/sni_passthrough.go
@@ -17,7 +17,7 @@ import (
 	"github.com/rs/zerolog/log"
 	acl "github.com/yusing/godoxy/internal/acl/types"
 	autocert "github.com/yusing/godoxy/internal/autocert/types"
-	"github.com/yusing/godoxy/internal/common"
+	netutils "github.com/yusing/godoxy/internal/net"
 	nettypes "github.com/yusing/godoxy/internal/net/types"
 	"github.com/yusing/godoxy/internal/types"
 )
@@ -186,41 +186,14 @@ func asSNIRoute(route types.StreamRoute) bool {
 	listenURL := route.ListenURL()
 	switch listenURL.Scheme {
 	case "tcp", "tcp4", "tcp6":
-		return isSharedHTTPSListenAddr(listenURL.Host)
+		return netutils.IsSharedHTTPSListenAddr(listenURL.Host)
 	default:
 		return false
 	}
 }
 
 func sniListenAddr(route types.StreamRoute) string {
-	addr := route.ListenURL().Host
-	if isSharedHTTPSListenAddr(addr) {
-		return common.ProxyHTTPSAddr
-	}
-	return addr
-}
-
-func isSharedHTTPSListenAddr(addr string) bool {
-	return listenAddrsEqual(addr, common.ProxyHTTPSAddr)
-}
-
-func listenAddrsEqual(addr, other string) bool {
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		return addr == other
-	}
-	otherHost, otherPort, err := net.SplitHostPort(other)
-	if err != nil {
-		return addr == other
-	}
-	if port != otherPort {
-		return false
-	}
-	return host == otherHost || isWildcardListenHost(host) && isWildcardListenHost(otherHost)
-}
-
-func isWildcardListenHost(host string) bool {
-	return host == "" || host == "0.0.0.0" || host == "::"
+	return netutils.SharedHTTPSListenAddr(route.ListenURL().Host)
 }
 
 func routeTerminatesTLS(route types.StreamRoute) bool {

--- a/internal/entrypoint/sni_passthrough.go
+++ b/internal/entrypoint/sni_passthrough.go
@@ -1,0 +1,277 @@
+package entrypoint
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pires/go-proxyproto"
+	"github.com/puzpuzpuz/xsync/v4"
+	"github.com/rs/zerolog/log"
+	acl "github.com/yusing/godoxy/internal/acl/types"
+	autocert "github.com/yusing/godoxy/internal/autocert/types"
+	"github.com/yusing/godoxy/internal/common"
+	nettypes "github.com/yusing/godoxy/internal/net/types"
+	"github.com/yusing/godoxy/internal/types"
+)
+
+var errClientHelloRead = errors.New("client hello read")
+
+const clientHelloTimeout = 5 * time.Second
+
+type sniRouter struct {
+	ep        *Entrypoint
+	mu        sync.Mutex
+	listeners *xsync.Map[string, *sniListener]
+	routes    *xsync.Map[string, types.StreamRoute]
+}
+
+type sniListener struct {
+	net.Listener
+	router *sniRouter
+	addr   string
+	mu     sync.Mutex
+	https  chan net.Conn
+	closed bool
+}
+
+func newSNIRouter(ep *Entrypoint) *sniRouter {
+	r := &sniRouter{
+		ep:        ep,
+		listeners: xsync.NewMap[string, *sniListener](),
+		routes:    xsync.NewMap[string, types.StreamRoute](),
+	}
+	ep.task.OnCancel("sni_router", func() { _ = r.Close() })
+	return r
+}
+
+func (r *sniRouter) AddRoute(route types.StreamRoute) error {
+	if _, ok := route.Stream().(nettypes.ConnProxy); !ok {
+		return fmt.Errorf("route %q stream does not support accepted connection proxying", route.Name())
+	}
+	if routeTerminatesTLS(route) && autocert.FromCtx(r.ep.task.Context()) == nil {
+		return fmt.Errorf("route %q tls_termination requires an autocert provider", route.Name())
+	}
+	if _, err := r.Listen(route.ListenURL().Host); err != nil {
+		return err
+	}
+	r.routes.Store(sniRouteKey(route.ListenURL().Host, route.Key()), route)
+	return nil
+}
+
+func (r *sniRouter) DelRoute(route types.StreamRoute) {
+	r.routes.Delete(sniRouteKey(route.ListenURL().Host, route.Key()))
+}
+
+func (r *sniRouter) Listen(addr string) (net.Listener, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if listener, ok := r.listeners.Load(addr); ok {
+		return listener, nil
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	if r.ep.cfg.SupportProxyProtocol {
+		ln = &proxyproto.Listener{Listener: ln}
+	}
+	if aclCfg := acl.FromCtx(r.ep.task.Context()); aclCfg != nil {
+		ln = aclCfg.WrapTCP(ln)
+	}
+	listener := &sniListener{
+		Listener: ln,
+		router:   r,
+		addr:     addr,
+		https:    make(chan net.Conn, 128),
+	}
+	r.listeners.Store(addr, listener)
+	go r.accept(addr, listener)
+	return listener, nil
+}
+
+func (r *sniRouter) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var err error
+	for addr, listener := range r.listeners.Range {
+		err = errors.Join(err, listener.Close())
+		r.listeners.Delete(addr)
+	}
+	return err
+}
+
+func (r *sniRouter) accept(addr string, listener *sniListener) {
+	for {
+		conn, err := listener.Listener.Accept()
+		if err != nil {
+			current, ok := r.listeners.Load(addr)
+			if !ok || current != listener || errors.Is(err, net.ErrClosed) {
+				return
+			}
+			log.Err(err).Msg("failed to accept sni-routed connection")
+			continue
+		}
+		go r.handle(listener, conn)
+	}
+}
+
+func (r *sniRouter) handle(listener *sniListener, conn net.Conn) {
+	_ = conn.SetReadDeadline(time.Now().Add(clientHelloTimeout))
+	serverName, replayConn, err := readClientHelloServerName(conn)
+	_ = conn.SetReadDeadline(time.Time{})
+	if err != nil {
+		r.forwardHTTPS(listener, replayConn)
+		return
+	}
+	route, ok := r.match(listener, serverName)
+	if !ok {
+		r.forwardHTTPS(listener, replayConn)
+		return
+	}
+	proxy := route.Stream().(nettypes.ConnProxy)
+	if routeTerminatesTLS(route) {
+		terminatedConn, err := r.terminateTLS(route.Task().Context(), replayConn)
+		if err != nil {
+			log.Debug().Err(err).Str("server_name", serverName).Msg("failed to terminate tls for tcp route")
+			_ = replayConn.Close()
+			return
+		}
+		replayConn = terminatedConn
+	}
+	proxy.ProxyConn(route.Task().Context(), replayConn)
+}
+
+func (r *sniRouter) forwardHTTPS(listener *sniListener, conn net.Conn) {
+	listener.forwardHTTPS(conn)
+}
+
+func (r *sniRouter) terminateTLS(ctx context.Context, conn net.Conn) (net.Conn, error) {
+	provider := autocert.FromCtx(r.ep.task.Context())
+	tlsConn := tls.Server(conn, &tls.Config{GetCertificate: provider.GetCert, MinVersion: tls.VersionTLS12})
+	_ = conn.SetReadDeadline(time.Now().Add(clientHelloTimeout))
+	err := tlsConn.HandshakeContext(ctx)
+	_ = conn.SetReadDeadline(time.Time{})
+	return tlsConn, err
+}
+
+func (r *sniRouter) match(listener *sniListener, serverName string) (types.StreamRoute, bool) {
+	key, ok := matchSNI(serverName, r.ep.findRouteKeyFunc, func(key string) bool {
+		_, ok := r.routes.Load(sniRouteKey(listener.addr, key))
+		return ok
+	})
+	if !ok {
+		return nil, false
+	}
+	return r.routes.Load(sniRouteKey(listener.addr, key))
+}
+
+func matchSNI(serverName string, findKey findRouteKeyFunc, exists func(string) bool) (string, bool) {
+	serverName = normalizeSNIName(serverName)
+	if serverName == "" {
+		return "", false
+	}
+	return findKey(serverName, exists)
+}
+
+func asSNIRoute(route types.StreamRoute) bool {
+	listenURL := route.ListenURL()
+	switch listenURL.Scheme {
+	case "tcp", "tcp4", "tcp6":
+		return listenURL.Host == common.ProxyHTTPSAddr
+	default:
+		return false
+	}
+}
+
+func routeTerminatesTLS(route types.StreamRoute) bool {
+	terminatingRoute, ok := route.(interface{ TerminatesTLS() bool })
+	return ok && terminatingRoute.TerminatesTLS()
+}
+
+func (l *sniListener) Accept() (net.Conn, error) {
+	conn, ok := <-l.https
+	if !ok {
+		return nil, net.ErrClosed
+	}
+	return conn, nil
+}
+
+func (l *sniListener) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		return nil
+	}
+	l.closed = true
+	err := l.Listener.Close()
+	close(l.https)
+	if l.router != nil {
+		l.router.listeners.Delete(l.addr)
+	}
+	return err
+}
+
+func (l *sniListener) forwardHTTPS(conn net.Conn) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		_ = conn.Close()
+		return
+	}
+	select {
+	case l.https <- conn:
+	default:
+		_ = conn.Close()
+	}
+}
+
+func normalizeSNIName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	name, _, _ = strings.Cut(name, ":")
+	return name
+}
+
+func sniRouteKey(addr, name string) string {
+	return addr + "\x00" + normalizeSNIName(name)
+}
+
+type clientHelloReadConn struct {
+	net.Conn
+	reader io.Reader
+}
+
+func (c *clientHelloReadConn) Read(p []byte) (int, error)  { return c.reader.Read(p) }
+func (c *clientHelloReadConn) Write(p []byte) (int, error) { return len(p), nil }
+
+type replayConn struct {
+	net.Conn
+	reader io.Reader
+}
+
+func (c *replayConn) Read(p []byte) (int, error) { return c.reader.Read(p) }
+
+func readClientHelloServerName(conn net.Conn) (string, net.Conn, error) {
+	var captured bytes.Buffer
+	var serverName string
+	tlsConn := tls.Server(&clientHelloReadConn{Conn: conn, reader: io.TeeReader(conn, &captured)}, &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+			serverName = normalizeSNIName(hello.ServerName)
+			return nil, errClientHelloRead
+		},
+	})
+	err := tlsConn.Handshake()
+	replayed := &replayConn{Conn: conn, reader: io.MultiReader(bytes.NewReader(captured.Bytes()), conn)}
+	if errors.Is(err, errClientHelloRead) {
+		return serverName, replayed, nil
+	}
+	return serverName, replayed, err
+}

--- a/internal/entrypoint/sni_passthrough.go
+++ b/internal/entrypoint/sni_passthrough.go
@@ -59,15 +59,16 @@ func (r *sniRouter) AddRoute(route types.StreamRoute) error {
 	if routeTerminatesTLS(route) && autocert.FromCtx(r.ep.task.Context()) == nil {
 		return fmt.Errorf("route %q tls_termination requires an autocert provider", route.Name())
 	}
-	if _, err := r.Listen(route.ListenURL().Host); err != nil {
+	addr := sniListenAddr(route)
+	if _, err := r.Listen(addr); err != nil {
 		return err
 	}
-	r.routes.Store(sniRouteKey(route.ListenURL().Host, route.Key()), route)
+	r.routes.Store(sniRouteKey(addr, route.Key()), route)
 	return nil
 }
 
 func (r *sniRouter) DelRoute(route types.StreamRoute) {
-	r.routes.Delete(sniRouteKey(route.ListenURL().Host, route.Key()))
+	r.routes.Delete(sniRouteKey(sniListenAddr(route), route.Key()))
 }
 
 func (r *sniRouter) Listen(addr string) (net.Listener, error) {
@@ -185,10 +186,41 @@ func asSNIRoute(route types.StreamRoute) bool {
 	listenURL := route.ListenURL()
 	switch listenURL.Scheme {
 	case "tcp", "tcp4", "tcp6":
-		return listenURL.Host == common.ProxyHTTPSAddr
+		return isSharedHTTPSListenAddr(listenURL.Host)
 	default:
 		return false
 	}
+}
+
+func sniListenAddr(route types.StreamRoute) string {
+	addr := route.ListenURL().Host
+	if isSharedHTTPSListenAddr(addr) {
+		return common.ProxyHTTPSAddr
+	}
+	return addr
+}
+
+func isSharedHTTPSListenAddr(addr string) bool {
+	return listenAddrsEqual(addr, common.ProxyHTTPSAddr)
+}
+
+func listenAddrsEqual(addr, other string) bool {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr == other
+	}
+	otherHost, otherPort, err := net.SplitHostPort(other)
+	if err != nil {
+		return addr == other
+	}
+	if port != otherPort {
+		return false
+	}
+	return host == otherHost || isWildcardListenHost(host) && isWildcardListenHost(otherHost)
+}
+
+func isWildcardListenHost(host string) bool {
+	return host == "" || host == "0.0.0.0" || host == "::"
 }
 
 func routeTerminatesTLS(route types.StreamRoute) bool {

--- a/internal/entrypoint/sni_passthrough_test.go
+++ b/internal/entrypoint/sni_passthrough_test.go
@@ -1,0 +1,106 @@
+package entrypoint
+
+import (
+	"crypto/tls"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSNIMatchUsesAliasOrFQDN(t *testing.T) {
+	routes := map[string]bool{
+		"site2":             true,
+		"fqdn.example.test": true,
+	}
+	exists := func(key string) bool { return routes[key] }
+
+	key, ok := matchSNI("site2.example.test", findRouteKeyAnyDomain, exists)
+	require.True(t, ok)
+	require.Equal(t, "site2", key)
+
+	key, ok = matchSNI("fqdn.example.test", findRouteKeyAnyDomain, exists)
+	require.True(t, ok)
+	require.Equal(t, "fqdn.example.test", key)
+
+	_, ok = matchSNI("other.example.test", findRouteKeyAnyDomain, exists)
+	require.False(t, ok)
+}
+
+func TestSNIMatchHonorsDomainFilters(t *testing.T) {
+	ep := NewTestEntrypoint(t, nil)
+	ep.SetFindRouteDomains([]string{".example.test"})
+	exists := func(key string) bool { return key == "db" }
+
+	key, ok := matchSNI("db.example.test", ep.findRouteKeyFunc, exists)
+	require.True(t, ok)
+	require.Equal(t, "db", key)
+
+	_, ok = matchSNI("db.attacker.test", ep.findRouteKeyFunc, exists)
+	require.False(t, ok)
+}
+
+func TestSNIRouterListensPerHTTPSAddress(t *testing.T) {
+	ep := NewTestEntrypoint(t, nil)
+	t.Cleanup(func() {
+		require.NoError(t, ep.sni.Close())
+	})
+
+	addr1 := reserveSNIListenAddr(t)
+	addr2 := reserveSNIListenAddr(t)
+
+	listener1, err := ep.sni.Listen(addr1)
+	require.NoError(t, err)
+	listener2, err := ep.sni.Listen(addr2)
+	require.NoError(t, err)
+
+	require.NotSame(t, listener1, listener2)
+	require.Equal(t, addr1, listener1.Addr().String())
+	require.Equal(t, addr2, listener2.Addr().String())
+	require.Equal(t, 2, ep.sni.listeners.Size())
+
+	again, err := ep.sni.Listen(addr1)
+	require.NoError(t, err)
+	require.Same(t, listener1, again)
+}
+
+func TestReadClientHelloServerNameReplaysBytes(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	clientErr := make(chan error, 1)
+	go func() {
+		client := tls.Client(clientConn, &tls.Config{
+			ServerName:         "WWW.Site2.Domain.TLD",
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS12,
+		})
+		clientErr <- client.Handshake()
+	}()
+
+	serverName, replayConn, err := readClientHelloServerName(serverConn)
+	require.NoError(t, err)
+	require.Equal(t, "www.site2.domain.tld", serverName)
+
+	_ = replayConn.SetReadDeadline(time.Now().Add(time.Second))
+	first := make([]byte, 1)
+	_, err = io.ReadFull(replayConn, first)
+	require.NoError(t, err)
+	require.Equal(t, byte(0x16), first[0])
+
+	clientConn.Close()
+	require.Error(t, <-clientErr)
+}
+
+func reserveSNIListenAddr(t *testing.T) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := listener.Addr().String()
+	require.NoError(t, listener.Close())
+	return addr
+}

--- a/internal/entrypoint/sni_passthrough_test.go
+++ b/internal/entrypoint/sni_passthrough_test.go
@@ -79,8 +79,11 @@ func TestSharedHTTPSListenAddrMatchesConfiguredWildcard(t *testing.T) {
 		net.JoinHostPort("::", port),
 		net.JoinHostPort("0:0:0:0:0:0:0:0", port),
 	} {
-		require.Equal(t, isConfiguredWildcard, netutils.IsSharedHTTPSListenAddr(addr), addr)
-		require.True(t, netutils.IsWildcardListenHost(addr), addr)
+		a := addr
+		t.Run(a, func(t *testing.T) {
+			require.Equal(t, isConfiguredWildcard, netutils.IsSharedHTTPSListenAddr(a), a)
+			require.True(t, netutils.IsWildcardListenHost(a), a)
+		})
 	}
 
 	otherPort := "1"

--- a/internal/entrypoint/sni_passthrough_test.go
+++ b/internal/entrypoint/sni_passthrough_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	netutils "github.com/yusing/godoxy/internal/net"
 )
 
 func TestSNIMatchUsesAliasOrFQDN(t *testing.T) {
@@ -67,10 +68,10 @@ func TestSNIRouterListensPerHTTPSAddress(t *testing.T) {
 }
 
 func TestSharedHTTPSListenAddrMatchesWildcardDefault(t *testing.T) {
-	require.True(t, listenAddrsEqual("0.0.0.0:443", ":443"))
-	require.True(t, listenAddrsEqual("[::]:443", ":443"))
-	require.False(t, listenAddrsEqual("0.0.0.0:8443", ":443"))
-	require.False(t, listenAddrsEqual("127.0.0.1:443", ":443"))
+	require.True(t, netutils.IsSharedHTTPSListenAddr("0.0.0.0:443"))
+	require.True(t, netutils.IsSharedHTTPSListenAddr("[::]:443"))
+	require.False(t, netutils.IsSharedHTTPSListenAddr("0.0.0.0:8443"))
+	require.False(t, netutils.IsSharedHTTPSListenAddr("127.0.0.1:443"))
 }
 
 func TestReadClientHelloServerNameReplaysBytes(t *testing.T) {

--- a/internal/entrypoint/sni_passthrough_test.go
+++ b/internal/entrypoint/sni_passthrough_test.go
@@ -66,6 +66,13 @@ func TestSNIRouterListensPerHTTPSAddress(t *testing.T) {
 	require.Same(t, listener1, again)
 }
 
+func TestSharedHTTPSListenAddrMatchesWildcardDefault(t *testing.T) {
+	require.True(t, listenAddrsEqual("0.0.0.0:443", ":443"))
+	require.True(t, listenAddrsEqual("[::]:443", ":443"))
+	require.False(t, listenAddrsEqual("0.0.0.0:8443", ":443"))
+	require.False(t, listenAddrsEqual("127.0.0.1:443", ":443"))
+}
+
 func TestReadClientHelloServerNameReplaysBytes(t *testing.T) {
 	clientConn, serverConn := net.Pipe()
 	defer clientConn.Close()

--- a/internal/entrypoint/sni_passthrough_test.go
+++ b/internal/entrypoint/sni_passthrough_test.go
@@ -4,10 +4,12 @@ import (
 	"crypto/tls"
 	"io"
 	"net"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/yusing/godoxy/internal/common"
 	netutils "github.com/yusing/godoxy/internal/net"
 )
 
@@ -67,11 +69,26 @@ func TestSNIRouterListensPerHTTPSAddress(t *testing.T) {
 	require.Same(t, listener1, again)
 }
 
-func TestSharedHTTPSListenAddrMatchesWildcardDefault(t *testing.T) {
-	require.True(t, netutils.IsSharedHTTPSListenAddr("0.0.0.0:443"))
-	require.True(t, netutils.IsSharedHTTPSListenAddr("[::]:443"))
-	require.False(t, netutils.IsSharedHTTPSListenAddr("0.0.0.0:8443"))
-	require.False(t, netutils.IsSharedHTTPSListenAddr("127.0.0.1:443"))
+func TestSharedHTTPSListenAddrMatchesConfiguredWildcard(t *testing.T) {
+	port := strconv.Itoa(common.ProxyHTTPSPort)
+	require.True(t, netutils.IsSharedHTTPSListenAddr(common.ProxyHTTPSAddr))
+
+	isConfiguredWildcard := netutils.IsWildcardListenHost(common.ProxyHTTPSAddr)
+	for _, addr := range []string{
+		net.JoinHostPort("0.0.0.0", port),
+		net.JoinHostPort("::", port),
+		net.JoinHostPort("0:0:0:0:0:0:0:0", port),
+	} {
+		require.Equal(t, isConfiguredWildcard, netutils.IsSharedHTTPSListenAddr(addr), addr)
+		require.True(t, netutils.IsWildcardListenHost(addr), addr)
+	}
+
+	otherPort := "1"
+	if port == otherPort {
+		otherPort = "2"
+	}
+	require.False(t, netutils.IsSharedHTTPSListenAddr(net.JoinHostPort("0.0.0.0", otherPort)))
+	require.False(t, netutils.IsWildcardListenHost(net.JoinHostPort("127.0.0.1", port)))
 }
 
 func TestReadClientHelloServerNameReplaysBytes(t *testing.T) {

--- a/internal/idlewatcher/handle_stream.go
+++ b/internal/idlewatcher/handle_stream.go
@@ -8,6 +8,7 @@ import (
 )
 
 var _ nettypes.Stream = (*Watcher)(nil)
+var _ nettypes.ConnProxy = (*Watcher)(nil)
 
 // ListenAndServe implements nettypes.Stream.
 func (w *Watcher) ListenAndServe(ctx context.Context, predial, onRead nettypes.HookFunc) error {
@@ -26,6 +27,24 @@ func (w *Watcher) Close() error {
 // LocalAddr implements nettypes.Stream.
 func (w *Watcher) LocalAddr() net.Addr {
 	return w.stream.LocalAddr()
+}
+
+// ProxyConn implements nettypes.ConnProxy.
+func (w *Watcher) ProxyConn(ctx context.Context, conn net.Conn) {
+	proxy, ok := w.stream.(nettypes.ConnProxy)
+	if !ok {
+		_ = conn.Close()
+		return
+	}
+	if err := w.preDial(ctx, nil); err != nil {
+		_ = conn.Close()
+		return
+	}
+	proxy.ProxyConn(ctx, &readWatcherConn{
+		Conn:   conn,
+		ctx:    ctx,
+		onRead: func(ctx context.Context) error { return w.onRead(ctx, nil) },
+	})
 }
 
 func (w *Watcher) preDial(ctx context.Context, predial nettypes.HookFunc) error {
@@ -76,4 +95,23 @@ func (w *Watcher) wakeFromStream(ctx context.Context) error {
 	w.resetIdleTimer()
 	w.l.Debug().Stringer("url", w.hc.URL()).Msg("container is ready, passing through")
 	return nil
+}
+
+type readWatcherConn struct {
+	net.Conn
+	ctx    context.Context
+	onRead nettypes.HookFunc
+}
+
+func (c *readWatcherConn) Read(b []byte) (n int, err error) {
+	n, err = c.Conn.Read(b)
+	if err != nil {
+		return n, err
+	}
+	if c.onRead != nil {
+		if err = c.onRead(c.ctx); err != nil {
+			return n, err
+		}
+	}
+	return n, err
 }

--- a/internal/idlewatcher/handle_stream_test.go
+++ b/internal/idlewatcher/handle_stream_test.go
@@ -1,0 +1,64 @@
+package idlewatcher
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	idlewatchertypes "github.com/yusing/godoxy/internal/idlewatcher/types"
+	nettypes "github.com/yusing/godoxy/internal/net/types"
+)
+
+func TestWatcherProxyConnDelegatesToWrappedConnProxy(t *testing.T) {
+	w := newTestWatcher(t)
+	w.stream = &testConnProxyStream{readDone: make(chan struct{})}
+	w.state.Store(&containerState{
+		status: idlewatchertypes.ContainerStatusRunning,
+		ready:  true,
+	})
+	before := time.Now().Add(-time.Second)
+	w.lastReset.Store(before)
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+
+	go w.ProxyConn(t.Context(), serverConn)
+
+	_, err := clientConn.Write([]byte{1})
+	require.NoError(t, err)
+
+	select {
+	case <-w.stream.(*testConnProxyStream).readDone:
+	case <-time.After(time.Second):
+		t.Fatal("wrapped conn proxy did not read from accepted connection")
+	}
+	require.True(t, w.lastReset.Load().After(before))
+}
+
+type testConnProxyStream struct {
+	readDone chan struct{}
+}
+
+var _ nettypes.Stream = (*testConnProxyStream)(nil)
+var _ nettypes.ConnProxy = (*testConnProxyStream)(nil)
+
+func (s *testConnProxyStream) ListenAndServe(context.Context, nettypes.HookFunc, nettypes.HookFunc) error {
+	return nil
+}
+
+func (s *testConnProxyStream) LocalAddr() net.Addr {
+	return &net.TCPAddr{}
+}
+
+func (s *testConnProxyStream) Close() error {
+	return nil
+}
+
+func (s *testConnProxyStream) ProxyConn(_ context.Context, conn net.Conn) {
+	defer conn.Close()
+	var b [1]byte
+	_, _ = conn.Read(b[:])
+	close(s.readDone)
+}

--- a/internal/net/README.md
+++ b/internal/net/README.md
@@ -34,6 +34,9 @@ func IsSharedHTTPSListenAddr(addr string) bool
 func IsWildcardListenHost(host string) bool
 ```
 
+`IsWildcardListenHost` accepts bare hosts and host:port inputs, including
+bracketed IPv6, and treats unspecified IPv4/IPv6 addresses as wildcard binds.
+
 ## Usage
 
 ### Basic Usage

--- a/internal/net/README.md
+++ b/internal/net/README.md
@@ -10,6 +10,7 @@ The net package implements network utility functions that are used throughout Go
 
 - TCP connection testing (ping)
 - Connection utilities
+- Shared HTTPS listener address matching helpers
 
 ## Core Functions
 
@@ -18,6 +19,19 @@ The net package implements network utility functions that are used throughout Go
 ```go
 // PingTCP pings a TCP endpoint by attempting a connection.
 func PingTCP(ctx context.Context, ip net.IP, port int) error
+```
+
+### Shared HTTPS Listener Matching
+
+```go
+// SharedHTTPSListenAddr canonicalizes wildcard-equivalent HTTPS listener addrs.
+func SharedHTTPSListenAddr(addr string) string
+
+// IsSharedHTTPSListenAddr reports whether addr matches configured HTTPS_ADDR.
+func IsSharedHTTPSListenAddr(addr string) bool
+
+// IsWildcardListenHost reports whether host means all interfaces.
+func IsWildcardListenHost(host string) bool
 ```
 
 ## Usage

--- a/internal/net/listen_addr.go
+++ b/internal/net/listen_addr.go
@@ -2,6 +2,7 @@ package netutils
 
 import (
 	"net"
+	"strings"
 
 	"github.com/yusing/godoxy/internal/common"
 )
@@ -38,5 +39,18 @@ func listenAddrsEqual(addr, other string) bool {
 
 // IsWildcardListenHost reports whether host means all local interfaces.
 func IsWildcardListenHost(host string) bool {
-	return host == "" || host == "0.0.0.0" || host == "::"
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return true
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.TrimPrefix(host, "[")
+	host = strings.TrimSuffix(host, "]")
+	if host == "" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsUnspecified()
 }

--- a/internal/net/listen_addr.go
+++ b/internal/net/listen_addr.go
@@ -1,0 +1,42 @@
+package netutils
+
+import (
+	"net"
+
+	"github.com/yusing/godoxy/internal/common"
+)
+
+// SharedHTTPSListenAddr returns the configured HTTPS listener address when addr
+// is equivalent to it.
+func SharedHTTPSListenAddr(addr string) string {
+	if IsSharedHTTPSListenAddr(addr) {
+		return common.ProxyHTTPSAddr
+	}
+	return addr
+}
+
+// IsSharedHTTPSListenAddr reports whether addr is equivalent to the configured
+// HTTPS listener address.
+func IsSharedHTTPSListenAddr(addr string) bool {
+	return listenAddrsEqual(addr, common.ProxyHTTPSAddr)
+}
+
+func listenAddrsEqual(addr, other string) bool {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr == other
+	}
+	otherHost, otherPort, err := net.SplitHostPort(other)
+	if err != nil {
+		return addr == other
+	}
+	if port != otherPort {
+		return false
+	}
+	return host == otherHost || IsWildcardListenHost(host) && IsWildcardListenHost(otherHost)
+}
+
+// IsWildcardListenHost reports whether host means all local interfaces.
+func IsWildcardListenHost(host string) bool {
+	return host == "" || host == "0.0.0.0" || host == "::"
+}

--- a/internal/net/listen_addr_test.go
+++ b/internal/net/listen_addr_test.go
@@ -17,7 +17,10 @@ func TestIsWildcardListenHost(t *testing.T) {
 		net.JoinHostPort("::", "443"),
 		net.JoinHostPort("0:0:0:0:0:0:0:0", "443"),
 	} {
-		require.True(t, IsWildcardListenHost(host), host)
+		h := host
+		t.Run(h, func(t *testing.T) {
+			require.True(t, IsWildcardListenHost(h), h)
+		})
 	}
 
 	for _, host := range []string{
@@ -25,6 +28,9 @@ func TestIsWildcardListenHost(t *testing.T) {
 		net.JoinHostPort("127.0.0.1", "443"),
 		"localhost",
 	} {
-		require.False(t, IsWildcardListenHost(host), host)
+		h := host
+		t.Run(h, func(t *testing.T) {
+			require.False(t, IsWildcardListenHost(h), h)
+		})
 	}
 }

--- a/internal/net/listen_addr_test.go
+++ b/internal/net/listen_addr_test.go
@@ -1,0 +1,30 @@
+package netutils
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsWildcardListenHost(t *testing.T) {
+	for _, host := range []string{
+		"",
+		"0.0.0.0",
+		net.JoinHostPort("0.0.0.0", "443"),
+		"::",
+		"[::]",
+		net.JoinHostPort("::", "443"),
+		net.JoinHostPort("0:0:0:0:0:0:0:0", "443"),
+	} {
+		require.True(t, IsWildcardListenHost(host), host)
+	}
+
+	for _, host := range []string{
+		"127.0.0.1",
+		net.JoinHostPort("127.0.0.1", "443"),
+		"localhost",
+	} {
+		require.False(t, IsWildcardListenHost(host), host)
+	}
+}

--- a/internal/net/types/stream.go
+++ b/internal/net/types/stream.go
@@ -11,4 +11,8 @@ type Stream interface {
 	Close() error
 }
 
+type ConnProxy interface {
+	ProxyConn(ctx context.Context, conn net.Conn)
+}
+
 type HookFunc func(ctx context.Context) error

--- a/internal/route/README.md
+++ b/internal/route/README.md
@@ -93,11 +93,14 @@ port: 443
 inbound_mtls_profile: corp-clients
 ```
 
-`TLSTermination` is valid only for TCP routes on the shared HTTPS listener. When
-enabled, Godoxy matches the TLS ClientHello SNI to the TCP route alias, completes
-TLS with the configured autocert provider, and proxies decrypted plaintext to the
-TCP target. Without it, matching HTTPS-listener TCP routes use SNI passthrough
-and the upstream target keeps serving its own certificate.
+`TLSTermination` (`tls_termination`) is valid only for TCP routes on the shared
+HTTPS listener. Route validation checks the listener address, and SNI route
+registration rejects TLS termination unless an autocert provider is configured.
+When enabled, Godoxy matches the TLS ClientHello SNI to the TCP route alias,
+terminates TLS with the configured autocert provider, and proxies decrypted
+plaintext to the TCP target. Leave `tls_termination` disabled when autocert is
+absent; matching HTTPS-listener TCP routes then remain SNI passthrough and the
+upstream target keeps serving its own certificate.
 
 ```go
 type Scheme string

--- a/internal/route/README.md
+++ b/internal/route/README.md
@@ -55,6 +55,7 @@ type Route struct {
     Middlewares map[string]types.LabelMap
     Homepage    *homepage.ItemConfig
     AccessLog   *accesslog.RequestLoggerConfig
+    TLSTermination bool
     Agent       string
     Idlewatcher *types.IdlewatcherConfig
 
@@ -91,6 +92,12 @@ scheme: https
 port: 443
 inbound_mtls_profile: corp-clients
 ```
+
+`TLSTermination` is valid only for TCP routes on the shared HTTPS listener. When
+enabled, Godoxy matches the TLS ClientHello SNI to the TCP route alias, completes
+TLS with the configured autocert provider, and proxies decrypted plaintext to the
+TCP target. Without it, matching HTTPS-listener TCP routes use SNI passthrough
+and the upstream target keeps serving its own certificate.
 
 ```go
 type Scheme string

--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -66,6 +66,7 @@ type (
 		Homepage                 *homepage.ItemConfig           `json:"homepage"`
 		AccessLog                *accesslog.RequestLoggerConfig `json:"access_log,omitempty" extensions:"x-nullable"`
 		RelayProxyProtocolHeader bool                           `json:"relay_proxy_protocol_header,omitempty"` // TCP only: relay PROXY protocol header to the destination
+		TLSTermination           bool                           `json:"tls_termination,omitempty"`             // TCP only: terminate inbound TLS on the shared HTTPS listener before proxying plaintext to the destination
 		Agent                    string                         `json:"agent,omitempty"`
 
 		Proxmox *proxmox.NodeConfig `json:"proxmox,omitempty" extensions:"x-nullable"`
@@ -335,6 +336,9 @@ func (r *Route) validate() error {
 	}
 	if r.RelayProxyProtocolHeader && r.Scheme != route.SchemeTCP {
 		errs.Adds("relay_proxy_protocol_header is only supported for tcp routes")
+	}
+	if r.TLSTermination && r.Scheme != route.SchemeTCP {
+		errs.Adds("tls_termination is only supported for tcp routes")
 	}
 
 	if errs.HasError() {
@@ -791,6 +795,10 @@ func (r *Route) ContainerInfo() *types.Container {
 
 func (r *Route) InboundMTLSProfileRef() string {
 	return r.InboundMTLSProfile
+}
+
+func (r *Route) TerminatesTLS() bool {
+	return r.TLSTermination
 }
 
 func (r *Route) IsDocker() bool {

--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -340,7 +340,7 @@ func (r *Route) validate() error {
 	if r.TLSTermination && r.Scheme != route.SchemeTCP {
 		errs.Adds("tls_termination is only supported for tcp routes")
 	}
-	if r.TLSTermination && r.Scheme == route.SchemeTCP && r.LisURL != nil && !isSharedHTTPSListenAddr(r.LisURL.Host) {
+	if r.TLSTermination && r.Scheme == route.SchemeTCP && r.LisURL != nil && !netutils.IsSharedHTTPSListenAddr(r.LisURL.Host) {
 		errs.Adds("tls_termination is only supported on the shared HTTPS listener")
 	}
 
@@ -371,25 +371,6 @@ func (r *Route) validate() error {
 		r.ExcludedReason = r.findExcludedReason()
 	}
 	return nil
-}
-
-func isSharedHTTPSListenAddr(addr string) bool {
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		return addr == common.ProxyHTTPSAddr
-	}
-	httpsHost, httpsPort, err := net.SplitHostPort(common.ProxyHTTPSAddr)
-	if err != nil {
-		return addr == common.ProxyHTTPSAddr
-	}
-	if port != httpsPort {
-		return false
-	}
-	return host == httpsHost || isWildcardListenHost(host) && isWildcardListenHost(httpsHost)
-}
-
-func isWildcardListenHost(host string) bool {
-	return host == "" || host == "0.0.0.0" || host == "::"
 }
 
 func (r *Route) validateRules() error {

--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -340,6 +340,9 @@ func (r *Route) validate() error {
 	if r.TLSTermination && r.Scheme != route.SchemeTCP {
 		errs.Adds("tls_termination is only supported for tcp routes")
 	}
+	if r.TLSTermination && r.Scheme == route.SchemeTCP && r.LisURL != nil && !isSharedHTTPSListenAddr(r.LisURL.Host) {
+		errs.Adds("tls_termination is only supported on the shared HTTPS listener")
+	}
 
 	if errs.HasError() {
 		return errs.Error()
@@ -368,6 +371,25 @@ func (r *Route) validate() error {
 		r.ExcludedReason = r.findExcludedReason()
 	}
 	return nil
+}
+
+func isSharedHTTPSListenAddr(addr string) bool {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr == common.ProxyHTTPSAddr
+	}
+	httpsHost, httpsPort, err := net.SplitHostPort(common.ProxyHTTPSAddr)
+	if err != nil {
+		return addr == common.ProxyHTTPSAddr
+	}
+	if port != httpsPort {
+		return false
+	}
+	return host == httpsHost || isWildcardListenHost(host) && isWildcardListenHost(httpsHost)
+}
+
+func isWildcardListenHost(host string) bool {
+	return host == "" || host == "0.0.0.0" || host == "::"
 }
 
 func (r *Route) validateRules() error {

--- a/internal/route/route_test.go
+++ b/internal/route/route_test.go
@@ -91,6 +91,19 @@ func TestRouteValidate(t *testing.T) {
 		require.ErrorContains(t, err, "relay_proxy_protocol_header is only supported for tcp routes")
 	})
 
+	t.Run("TLSTerminationTCPOnly", func(t *testing.T) {
+		r := &Route{
+			Alias:          "test-udp-tls",
+			Scheme:         route.SchemeUDP,
+			Host:           "127.0.0.1",
+			Port:           route.Port{Proxy: 53, Listening: 53},
+			TLSTermination: true,
+		}
+		err := r.Validate()
+		require.Error(t, err, "Validate should reject TLS termination on UDP routes")
+		require.ErrorContains(t, err, "tls_termination is only supported for tcp routes")
+	})
+
 	t.Run("InboundMTLSProfileHTTPOnly", func(t *testing.T) {
 		r := &Route{
 			Alias:              "test-udp-mtls",

--- a/internal/route/route_test.go
+++ b/internal/route/route_test.go
@@ -104,6 +104,19 @@ func TestRouteValidate(t *testing.T) {
 		require.ErrorContains(t, err, "tls_termination is only supported for tcp routes")
 	})
 
+	t.Run("TLSTerminationSharedHTTPSOnly", func(t *testing.T) {
+		r := &Route{
+			Alias:          "test-tcp-tls",
+			Scheme:         route.SchemeTCP,
+			Host:           "127.0.0.1",
+			Port:           route.Port{Proxy: 1883, Listening: common.ProxyHTTPSPort + 1},
+			TLSTermination: true,
+		}
+		err := r.Validate()
+		require.Error(t, err, "Validate should reject TLS termination outside shared HTTPS listener")
+		require.ErrorContains(t, err, "tls_termination is only supported on the shared HTTPS listener")
+	})
+
 	t.Run("InboundMTLSProfileHTTPOnly", func(t *testing.T) {
 		r := &Route{
 			Alias:              "test-udp-mtls",

--- a/internal/route/stream/README.md
+++ b/internal/route/stream/README.md
@@ -179,15 +179,33 @@ const (
 routes:
   ssh-proxy:
     scheme: tcp4
-      bind: 0.0.0.0 # optional
-      port: 2222:22 # listening port: target port
-      relay_proxy_protocol_header: true # optional, tcp only
+    bind: 0.0.0.0 # optional
+    port: 2222:22 # listening port: target port
+    relay_proxy_protocol_header: true # optional, tcp only
 
   dns-proxy:
     scheme: udp4
     bind: 0.0.0.0 # optional
     port: 53:53 # listening port: target port
+
+  site2:
+    scheme: tcp
+    host: 100.64.0.10
+    port: 443:443 # listen on HTTPS_ADDR and proxy to upstream TLS port
+
+  mqtt:
+    scheme: tcp
+    host: 100.64.0.20
+    port: 443:1883 # listen on HTTPS_ADDR and proxy plaintext to upstream MQTT
+    tls_termination: true
 ```
+
+### SNI TLS passthrough and termination
+
+TCP routes on `HTTPS_ADDR` match TLS SNI by alias, same as HTTP routes: `site2`
+matches `site2.example.test`; `site2.example.test` matches that FQDN. Matches
+proxy raw TCP by default. Set `tls_termination: true` to terminate TLS with the
+configured autocert provider and proxy plaintext upstream.
 
 ### Docker Labels
 
@@ -225,6 +243,7 @@ Log context includes: `protocol`, `listen`, `dst`, `action`
 - ACL wrapping available for TCP and UDP listeners
 - PROXY protocol support for original client IP
 - TCP routes can optionally emit a fresh upstream PROXY v2 header with `relay_proxy_protocol_header: true`
+- TCP routes on the HTTPS listener can either passthrough TLS or terminate TLS and proxy plaintext with `tls_termination: true`
 - No protocol validation (relies on upstream)
 - Connection limits managed by OS
 

--- a/internal/route/stream/README.md
+++ b/internal/route/stream/README.md
@@ -188,15 +188,17 @@ routes:
     bind: 0.0.0.0 # optional
     port: 53:53 # listening port: target port
 
+  # The 443 listening ports below assume the default HTTPS_ADDR=:443.
+  # If HTTPS_ADDR uses a different port, use that listening port instead.
   site2:
     scheme: tcp
     host: 100.64.0.10
-    port: 443:443 # listen on HTTPS_ADDR and proxy to upstream TLS port
+    port: 443:443 # listen on HTTPS_ADDR port and proxy to upstream TLS port
 
   mqtt:
     scheme: tcp
     host: 100.64.0.20
-    port: 443:1883 # listen on HTTPS_ADDR and proxy plaintext to upstream MQTT
+    port: 443:1883 # listen on HTTPS_ADDR port and proxy plaintext to upstream MQTT
     tls_termination: true
 ```
 
@@ -206,6 +208,11 @@ TCP routes on `HTTPS_ADDR` match TLS SNI by alias, same as HTTP routes: `site2`
 matches `site2.example.test`; `site2.example.test` matches that FQDN. Matches
 proxy raw TCP by default. Set `tls_termination: true` to terminate TLS with the
 configured autocert provider and proxy plaintext upstream.
+
+The `site2` and `mqtt` examples use listening port `443` because the default
+`HTTPS_ADDR` is `:443`. `tls_termination` is validated against the configured
+shared HTTPS listener, not the literal value `443`, and is rejected unless the
+TCP route listens on `HTTPS_ADDR`.
 
 ### Docker Labels
 
@@ -243,7 +250,7 @@ Log context includes: `protocol`, `listen`, `dst`, `action`
 - ACL wrapping available for TCP and UDP listeners
 - PROXY protocol support for original client IP
 - TCP routes can optionally emit a fresh upstream PROXY v2 header with `relay_proxy_protocol_header: true`
-- TCP routes on the HTTPS listener can either passthrough TLS or terminate TLS and proxy plaintext with `tls_termination: true`
+- TCP routes on the configured HTTPS listener can passthrough TLS, or terminate TLS with autocert and proxy plaintext with `tls_termination: true`
 - No protocol validation (relies on upstream)
 - Connection limits managed by OS
 

--- a/internal/route/stream/tcp_tcp.go
+++ b/internal/route/stream/tcp_tcp.go
@@ -126,12 +126,12 @@ func (s *TCPTCPStream) listen(ctx context.Context) {
 					continue
 				}
 			}
-			go s.handle(ctx, conn)
+			go s.ProxyConn(ctx, conn)
 		}
 	}
 }
 
-func (s *TCPTCPStream) handle(ctx context.Context, conn net.Conn) {
+func (s *TCPTCPStream) ProxyConn(ctx context.Context, conn net.Conn) {
 	defer conn.Close()
 
 	if s.preDial != nil {

--- a/internal/route/stream/tcp_tcp_test.go
+++ b/internal/route/stream/tcp_tcp_test.go
@@ -146,3 +146,36 @@ func TestTCPTCPStreamRelayProxyProtocolUsesIncomingProxyHeader(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte("pong"), payload)
 }
+
+func TestTCPTCPStreamProxyConnRelaysAcceptedConnection(t *testing.T) {
+	upstreamLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer upstreamLn.Close()
+
+	s, err := NewTCPTCPStream("tcp", "tcp", "127.0.0.1:0", upstreamLn.Addr().String(), nil, false)
+	require.NoError(t, err)
+
+	proxy, ok := s.(interface {
+		ProxyConn(context.Context, net.Conn)
+	})
+	require.True(t, ok)
+
+	clientConn, muxConn := net.Pipe()
+	defer clientConn.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go proxy.ProxyConn(ctx, muxConn)
+
+	_, err = clientConn.Write([]byte("hello"))
+	require.NoError(t, err)
+
+	upstreamConn, err := upstreamLn.Accept()
+	require.NoError(t, err)
+	defer upstreamConn.Close()
+
+	payload := make([]byte, 5)
+	_, err = io.ReadFull(upstreamConn, payload)
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello"), payload)
+}

--- a/scripts/tcp_echo_test.ts
+++ b/scripts/tcp_echo_test.ts
@@ -1,0 +1,240 @@
+#!/usr/bin/env bun
+import { spawn } from "node:child_process";
+import net from "node:net";
+import tls from "node:tls";
+
+const proxyHost = "127.0.0.1";
+const proxyPort = 443;
+const composeFile = "compose.yml";
+const echoService = "tcp_echo_server";
+const routeReadyTimeoutMs = 30_000;
+
+type EchoTest = {
+  name: string;
+  serverName: string;
+  payload: Buffer;
+};
+
+type CommandResult = {
+  code: number;
+  output: string;
+};
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function runCommand(command: string, args: string[]): Promise<CommandResult> {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let output = "";
+
+    child.stdout.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+    child.once("close", (code) => {
+      resolve({ code: code ?? 1, output });
+    });
+  });
+}
+
+async function ensureEchoServiceRunning(): Promise<void> {
+  const result = await runCommand("docker", [
+    "compose",
+    "-f",
+    composeFile,
+    "up",
+    "-d",
+    echoService,
+  ]);
+  if (result.code !== 0) {
+    throw new Error(`failed to start ${echoService}: ${result.output.trim()}`);
+  }
+  if (result.output.trim().length > 0) {
+    console.log(result.output.trim());
+  }
+}
+
+async function waitPort(port: number): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      const socket = await connectPlain(port);
+      socket.destroy();
+      return;
+    } catch (error) {
+      lastError = error;
+      await delay(100);
+    }
+  }
+
+  throw new Error(`GoDoxy localhost:${port} not ready: ${String(lastError)}`);
+}
+
+function connectPlain(port: number): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host: proxyHost, port });
+    const timeout = setTimeout(() => {
+      socket.destroy();
+      reject(new Error(`connect timeout on ${proxyHost}:${port}`));
+    }, 500);
+
+    socket.once("connect", () => {
+      clearTimeout(timeout);
+      resolve(socket);
+    });
+    socket.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+  });
+}
+
+function connectTLS(serverName: string): Promise<tls.TLSSocket> {
+  return new Promise((resolve, reject) => {
+    const socket = tls.connect({
+      host: proxyHost,
+      port: proxyPort,
+      servername: serverName,
+      rejectUnauthorized: false,
+    });
+    const timeout = setTimeout(() => {
+      socket.destroy();
+      reject(new Error(`tls connect timeout for SNI ${serverName}`));
+    }, 5_000);
+
+    socket.once("secureConnect", () => {
+      clearTimeout(timeout);
+      resolve(socket);
+    });
+    socket.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+  });
+}
+
+function readExact(socket: net.Socket, expectedBytes: number): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let receivedBytes = 0;
+
+    const cleanup = () => {
+      socket.off("data", onData);
+      socket.off("error", onError);
+      socket.off("end", onEnd);
+      socket.off("timeout", onTimeout);
+    };
+
+    const onData = (chunk: Buffer) => {
+      chunks.push(chunk);
+      receivedBytes += chunk.length;
+      if (receivedBytes >= expectedBytes) {
+        cleanup();
+        resolve(
+          Buffer.concat(chunks, receivedBytes).subarray(0, expectedBytes),
+        );
+      }
+    };
+
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+
+    const onEnd = () => {
+      cleanup();
+      resolve(Buffer.concat(chunks, receivedBytes));
+    };
+
+    const onTimeout = () => {
+      cleanup();
+      socket.destroy();
+      reject(
+        new Error(`read timeout after ${receivedBytes}/${expectedBytes} bytes`),
+      );
+    };
+
+    socket.setTimeout(5_000);
+    socket.on("data", onData);
+    socket.once("error", onError);
+    socket.once("end", onEnd);
+    socket.once("timeout", onTimeout);
+  });
+}
+
+async function expectEcho(test: EchoTest): Promise<void> {
+  const socket = await connectTLS(test.serverName);
+  socket.write(test.payload);
+  const received = await readExact(socket, test.payload.length);
+  socket.destroy();
+
+  if (!received.equals(test.payload)) {
+    throw new Error(
+      `echo mismatch: got ${JSON.stringify(received.toString())}`,
+    );
+  }
+}
+
+async function waitForRoute(test: EchoTest): Promise<void> {
+  const deadline = Date.now() + routeReadyTimeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      await expectEcho(test);
+      return;
+    } catch (error) {
+      lastError = error;
+      await delay(500);
+    }
+  }
+
+  throw new Error(`route ${test.serverName} not ready: ${String(lastError)}`);
+}
+
+async function main(): Promise<number> {
+  const tests: EchoTest[] = [
+    {
+      name: "godoxy TLS passthrough",
+      serverName: "tcp-echo-passthrough.my.app",
+      payload: Buffer.from("godoxy tls passthrough echo"),
+    },
+    {
+      name: "godoxy TLS termination",
+      serverName: "tcp-echo-termination.my.app",
+      payload: Buffer.from("godoxy tls termination echo"),
+    },
+  ];
+
+  try {
+    await ensureEchoServiceRunning();
+    await waitPort(proxyPort);
+  } catch (error) {
+    console.log(`tcp-echo-test: FAIL: ${String(error)}`);
+    return 1;
+  }
+
+  let failed = false;
+  for (const test of tests) {
+    try {
+      await waitForRoute(test);
+      console.log(`${test.name}: PASS`);
+    } catch (error) {
+      failed = true;
+      console.log(`${test.name}: FAIL: ${String(error)}`);
+    }
+  }
+
+  if (failed) return 1;
+
+  console.log("tcp-echo-test: PASS");
+  return 0;
+}
+
+process.exit(await main());


### PR DESCRIPTION
#218 #223 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TCP routes on the shared HTTPS listener can match TLS SNI aliases and optionally terminate TLS (tls_termination), proxying decrypted plaintext to the TCP upstream.
  * SNI passthrough routing for TCP on the HTTPS listener with proper fallback when termination is not enabled.
  * Added a local TCP echo service and automated tcp-echo test to validate passthrough vs termination behavior.

* **Documentation**
  * Updated config examples and docs clarifying SNI-based TCP routing, default passthrough behavior, and tls_termination usage.

* **Tests**
  * New test suites covering SNI routing, shared-HTTPS address helpers, and connection proxying behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->