### PR TITLE
feat(entrypoint): add leading-label wildcard HTTP route aliases

### DIFF
--- a/internal/entrypoint/README.md
+++ b/internal/entrypoint/README.md
@@ -9,6 +9,7 @@ The entrypoint package implements the primary HTTP handler that receives all inc
 ### Key Features
 
 - Domain-based route lookup with subdomain support
+- Leading-label wildcard aliases (`*.domain.com`) with exact-route fast path preserved
 - Short link (`go/<alias>` domain) handling
 - Middleware chain application
 - Route-specific promotion of middleware overlays into matching entrypoint middleware

--- a/internal/entrypoint/entrypoint_benchmark_test.go
+++ b/internal/entrypoint/entrypoint_benchmark_test.go
@@ -156,7 +156,7 @@ func benchmarkFindRoute(b *testing.B, aliases []string, host string) {
 	ep.SetFindRouteDomains([]string{})
 
 	for _, alias := range aliases {
-		addRoute := &route.Route{
+		routeConfig := &route.Route{
 			Alias:  alias,
 			Scheme: routeTypes.SchemeHTTP,
 			Host:   "localhost",
@@ -168,8 +168,9 @@ func benchmarkFindRoute(b *testing.B, aliases []string, host string) {
 				Disable: true,
 			},
 		}
-		_, err := route.NewStartedTestRoute(b, addRoute)
+		startedRoute, err := route.NewStartedTestRoute(b, routeConfig)
 		require.NoError(b, err)
+		require.False(b, startedRoute.ShouldExclude())
 	}
 
 	server, ok := ep.GetServer(":18080")

--- a/internal/entrypoint/entrypoint_benchmark_test.go
+++ b/internal/entrypoint/entrypoint_benchmark_test.go
@@ -150,3 +150,49 @@ func BenchmarkEntrypoint(b *testing.B) {
 		}
 	}
 }
+
+func benchmarkFindRoute(b *testing.B, aliases []string, host string) {
+	ep := NewTestEntrypoint(b, nil)
+	ep.SetFindRouteDomains([]string{})
+
+	for _, alias := range aliases {
+		addRoute := &route.Route{
+			Alias:  alias,
+			Scheme: routeTypes.SchemeHTTP,
+			Host:   "localhost",
+			Port: route.Port{
+				Listening: 18080,
+				Proxy:     8080,
+			},
+			HealthCheck: types.HealthCheckConfig{
+				Disable: true,
+			},
+		}
+		_, err := route.NewStartedTestRoute(b, addRoute)
+		require.NoError(b, err)
+	}
+
+	server, ok := ep.GetServer(":18080")
+	if !ok {
+		b.Fatal("server not found")
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		if route := server.FindRoute(host); route == nil {
+			b.Fatalf("route not found for %s", host)
+		}
+	}
+}
+
+func BenchmarkFindRouteExactNoWildcard(b *testing.B) {
+	benchmarkFindRoute(b, []string{"test"}, "test.domain.com")
+}
+
+func BenchmarkFindRouteExactWithWildcard(b *testing.B) {
+	benchmarkFindRoute(b, []string{"test", "*.domain.com"}, "test.domain.com")
+}
+
+func BenchmarkFindRouteWildcard(b *testing.B) {
+	benchmarkFindRoute(b, []string{"*.domain.com"}, "test.domain.com")
+}

--- a/internal/entrypoint/entrypoint_test.go
+++ b/internal/entrypoint/entrypoint_test.go
@@ -204,6 +204,67 @@ func TestFindRouteWithPort(t *testing.T) {
 	})
 }
 
+func TestFindRouteWildcardAlias(t *testing.T) {
+	t.Run("AnyDomain", func(t *testing.T) {
+		ep := NewTestEntrypoint(t, nil)
+		addRoute(t, "*.domain.com")
+
+		tests := []string{
+			"foo.domain.com",
+			"foo.domain.com:8080",
+		}
+		testsNoMatch := []string{
+			"domain.com",
+			"foo",
+			"foo.bar.domain.com",
+			"foo.domain.co",
+		}
+		run(t, ep, tests, testsNoMatch)
+	})
+
+	t.Run("ByDomains", func(t *testing.T) {
+		ep := NewTestEntrypoint(t, nil)
+		ep.SetFindRouteDomains([]string{
+			".domain.com",
+		})
+		addRoute(t, "*.domain.com")
+
+		tests := []string{
+			"foo.domain.com",
+			"foo.domain.com:8080",
+		}
+		testsNoMatch := []string{
+			"domain.com",
+			"foo.bar.domain.com",
+			"foo.domain.co",
+		}
+		run(t, ep, tests, testsNoMatch)
+	})
+}
+
+func TestFindRouteWildcardFallbackPrecedence(t *testing.T) {
+	ep := NewTestEntrypoint(t, nil)
+	addRoute(t, "*.domain.com")
+	addRoute(t, "app1")
+	addRoute(t, "api.domain.com")
+
+	server, ok := ep.GetServer(":" + strconv.Itoa(testHTTPRouteListenPort))
+	require.True(t, ok, "server not found")
+	require.NotNil(t, server)
+
+	route := server.FindRoute("app1.domain.com")
+	require.NotNil(t, route)
+	assert.Equal(t, "app1", route.Name())
+
+	route = server.FindRoute("api.domain.com")
+	require.NotNil(t, route)
+	assert.Equal(t, "api.domain.com", route.Name())
+
+	route = server.FindRoute("other.domain.com")
+	require.NotNil(t, route)
+	assert.Equal(t, "*.domain.com", route.Name())
+}
+
 func TestHealthInfoQueries(t *testing.T) {
 	ep := NewTestEntrypoint(t, nil)
 

--- a/internal/entrypoint/entrypoint_test.go
+++ b/internal/entrypoint/entrypoint_test.go
@@ -23,7 +23,7 @@ func addRoute(t *testing.T, alias string) {
 	ep := entrypoint.FromCtx(task.GetTestTask(t).Context())
 	require.NotNil(t, ep)
 
-	_, err := route.NewStartedTestRoute(t, &route.Route{
+	startedRoute, err := route.NewStartedTestRoute(t, &route.Route{
 		Alias:  alias,
 		Scheme: routeTypes.SchemeHTTP,
 		Port: route.Port{
@@ -38,7 +38,7 @@ func addRoute(t *testing.T, alias string) {
 		t.Fatal(err)
 	}
 
-	route, ok := ep.HTTPRoutes().Get(alias)
+	route, ok := ep.HTTPRoutes().Get(startedRoute.Key())
 	require.True(t, ok, "route not found")
 	require.NotNil(t, route)
 }
@@ -59,6 +59,9 @@ func run(t *testing.T, ep *Entrypoint, match []string, noMatch []string) {
 
 	for _, test := range noMatch {
 		t.Run(test, func(t *testing.T) {
+			route := server.FindRoute(test)
+			assert.Nil(t, route)
+
 			found, ok := ep.HTTPRoutes().Get(test)
 			assert.False(t, ok)
 			assert.Nil(t, found)
@@ -212,6 +215,8 @@ func TestFindRouteWildcardAlias(t *testing.T) {
 		tests := []string{
 			"foo.domain.com",
 			"foo.domain.com:8080",
+			"Foo.Domain.Com",
+			"foo.domain.com.",
 		}
 		testsNoMatch := []string{
 			"domain.com",
@@ -232,9 +237,26 @@ func TestFindRouteWildcardAlias(t *testing.T) {
 		tests := []string{
 			"foo.domain.com",
 			"foo.domain.com:8080",
+			"Foo.Domain.Com",
+			"foo.domain.com.",
 		}
 		testsNoMatch := []string{
 			"domain.com",
+			"foo.bar.domain.com",
+			"foo.domain.co",
+		}
+		run(t, ep, tests, testsNoMatch)
+	})
+
+	t.Run("CanonicalAlias", func(t *testing.T) {
+		ep := NewTestEntrypoint(t, nil)
+		addRoute(t, "*.Domain.Com.")
+
+		tests := []string{
+			"foo.domain.com",
+			"Foo.Domain.Com.",
+		}
+		testsNoMatch := []string{
 			"foo.bar.domain.com",
 			"foo.domain.co",
 		}

--- a/internal/entrypoint/http_server.go
+++ b/internal/entrypoint/http_server.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/puzpuzpuz/xsync/v4"
@@ -40,6 +41,8 @@ type httpServer struct {
 	routes *pool.Pool[types.HTTPRoute]
 
 	routeEntrypointOverlays atomic.Pointer[xsync.Map[string, *routeEntrypointOverlay]]
+	wildcardRoutes          atomic.Pointer[wildcardRouteIndex]
+	wildcardRoutesMu        sync.Mutex
 }
 
 type routeEntrypointOverlay struct {
@@ -68,6 +71,7 @@ func NewHTTPServer(ep *Entrypoint) HTTPServer {
 func newHTTPServer(ep *Entrypoint) *httpServer {
 	srv := &httpServer{ep: ep}
 	srv.resetRouteEntrypointOverlays()
+	srv.wildcardRoutes.Store(newWildcardRouteIndex())
 	return srv
 }
 
@@ -142,16 +146,21 @@ func (srv *httpServer) Close() {
 
 func (srv *httpServer) AddRoute(route types.HTTPRoute) {
 	srv.routes.Add(route)
+	srv.rebuildWildcardRoutes()
 	srv.routeEntrypointOverlayMap().Delete(route.Key())
 }
 
 func (srv *httpServer) DelRoute(route types.HTTPRoute) {
 	srv.routes.Del(route)
+	srv.rebuildWildcardRoutes()
 	srv.routeEntrypointOverlayMap().Delete(route.Key())
 }
 
 func (srv *httpServer) FindRoute(s string) types.HTTPRoute {
-	return srv.ep.findRouteFunc(srv.routes, s)
+	if route := srv.ep.findRouteFunc(srv.routes, s); route != nil {
+		return route
+	}
+	return srv.wildcardRouteIndex().Find(s)
 }
 
 func (srv *httpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -250,6 +259,29 @@ func (srv *httpServer) routeEntrypointOverlayMap() *xsync.Map[string, *routeEntr
 
 func (srv *httpServer) resetRouteEntrypointOverlays() {
 	srv.routeEntrypointOverlays.Store(newRouteEntrypointOverlayMap())
+}
+
+func (srv *httpServer) wildcardRouteIndex() *wildcardRouteIndex {
+	idx := srv.wildcardRoutes.Load()
+	if idx != nil {
+		return idx
+	}
+	idx = newWildcardRouteIndex()
+	if srv.wildcardRoutes.CompareAndSwap(nil, idx) {
+		return idx
+	}
+	return srv.wildcardRoutes.Load()
+}
+
+func (srv *httpServer) rebuildWildcardRoutes() {
+	srv.wildcardRoutesMu.Lock()
+	defer srv.wildcardRoutesMu.Unlock()
+
+	idx := newWildcardRouteIndex()
+	for _, route := range srv.routes.Iter {
+		idx.Add(route)
+	}
+	srv.wildcardRoutes.Store(idx)
 }
 
 func (srv *httpServer) compileRouteEntrypointOverlay(route types.HTTPRoute) (*routeEntrypointOverlay, error) {

--- a/internal/entrypoint/shortlink.go
+++ b/internal/entrypoint/shortlink.go
@@ -33,6 +33,9 @@ func (st *ShortLinkMatcher) AddRoute(alias string) {
 	if alias == "" {
 		return
 	}
+	if _, ok := wildcardSuffix(alias); ok {
+		return
+	}
 
 	if strings.Contains(alias, ".") { // FQDN alias
 		st.fqdnRoutes.Store(alias, alias)
@@ -57,6 +60,9 @@ func (st *ShortLinkMatcher) AddRoute(alias string) {
 func (st *ShortLinkMatcher) DelRoute(alias string) {
 	alias = strings.TrimSpace(alias)
 	if alias == "" {
+		return
+	}
+	if _, ok := wildcardSuffix(alias); ok {
 		return
 	}
 

--- a/internal/entrypoint/wildcard.go
+++ b/internal/entrypoint/wildcard.go
@@ -3,6 +3,7 @@ package entrypoint
 import (
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"github.com/yusing/godoxy/internal/types"
 )
 
@@ -18,8 +19,33 @@ func newWildcardRouteIndex() *wildcardRouteIndex {
 
 func (idx *wildcardRouteIndex) Add(route types.HTTPRoute) {
 	if suffix, ok := wildcardSuffix(route.Key()); ok {
+		existingRoute, exists := idx.oneLabel[suffix]
+		if exists && !preferWildcardRoute(route, existingRoute) {
+			return
+		}
+		if exists {
+			log.Warn().
+				Str("suffix", suffix).
+				Str("old_route", existingRoute.Key()).
+				Str("new_route", route.Key()).
+				Msg("replacing wildcard route with conflicting suffix")
+		}
 		idx.oneLabel[suffix] = route
 	}
+}
+
+type routePreference interface {
+	PreferOver(other any) bool
+}
+
+func preferWildcardRoute(route, existingRoute types.HTTPRoute) bool {
+	if preferredRoute, ok := route.(routePreference); ok {
+		return preferredRoute.PreferOver(existingRoute)
+	}
+	if preferredExisting, ok := existingRoute.(routePreference); ok {
+		return !preferredExisting.PreferOver(route)
+	}
+	return true
 }
 
 func (idx *wildcardRouteIndex) Find(host string) types.HTTPRoute {

--- a/internal/entrypoint/wildcard.go
+++ b/internal/entrypoint/wildcard.go
@@ -1,0 +1,51 @@
+package entrypoint
+
+import (
+	"strings"
+
+	"github.com/yusing/godoxy/internal/types"
+)
+
+type wildcardRouteIndex struct {
+	oneLabel map[string]types.HTTPRoute
+}
+
+func newWildcardRouteIndex() *wildcardRouteIndex {
+	return &wildcardRouteIndex{
+		oneLabel: make(map[string]types.HTTPRoute),
+	}
+}
+
+func (idx *wildcardRouteIndex) Add(route types.HTTPRoute) {
+	if suffix, ok := wildcardSuffix(route.Key()); ok {
+		idx.oneLabel[suffix] = route
+	}
+}
+
+func (idx *wildcardRouteIndex) Find(host string) types.HTTPRoute {
+	if idx == nil {
+		return nil
+	}
+	key, ok := wildcardLookupKey(host)
+	if !ok {
+		return nil
+	}
+	return idx.oneLabel[key]
+}
+
+func wildcardSuffix(alias string) (string, bool) {
+	suffix, ok := strings.CutPrefix(alias, "*.")
+	if !ok || suffix == "" || strings.Contains(suffix, "*") {
+		return "", false
+	}
+	return suffix, true
+}
+
+func wildcardLookupKey(host string) (string, bool) {
+	host, _, _ = strings.Cut(host, ":")
+	_, suffix, ok := strings.Cut(host, ".")
+	if !ok || suffix == "" {
+		return "", false
+	}
+	return suffix, true
+}

--- a/internal/entrypoint/wildcard.go
+++ b/internal/entrypoint/wildcard.go
@@ -34,6 +34,7 @@ func (idx *wildcardRouteIndex) Find(host string) types.HTTPRoute {
 }
 
 func wildcardSuffix(alias string) (string, bool) {
+	alias = strings.TrimSuffix(strings.ToLower(alias), ".")
 	suffix, ok := strings.CutPrefix(alias, "*.")
 	if !ok || suffix == "" || strings.Contains(suffix, "*") {
 		return "", false
@@ -43,6 +44,7 @@ func wildcardSuffix(alias string) (string, bool) {
 
 func wildcardLookupKey(host string) (string, bool) {
 	host, _, _ = strings.Cut(host, ":")
+	host = strings.TrimSuffix(strings.ToLower(host), ".")
 	_, suffix, ok := strings.Cut(host, ".")
 	if !ok || suffix == "" {
 		return "", false

--- a/internal/entrypoint/wildcard_test.go
+++ b/internal/entrypoint/wildcard_test.go
@@ -1,0 +1,44 @@
+package entrypoint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type preferredFakeHTTPRoute struct {
+	*fakeHTTPRoute
+	prefer bool
+}
+
+func (r *preferredFakeHTTPRoute) PreferOver(any) bool {
+	return r.prefer
+}
+
+func TestWildcardRouteIndexAddResolvesConflictingSuffix(t *testing.T) {
+	idx := newWildcardRouteIndex()
+	existing := newFakeHTTPRoute(t, "*.example.com", "")
+	replacement := &preferredFakeHTTPRoute{
+		fakeHTTPRoute: newFakeHTTPRoute(t, "*.example.com.", ""),
+		prefer:        true,
+	}
+
+	idx.Add(existing)
+	idx.Add(replacement)
+
+	require.Same(t, replacement, idx.Find("app.example.com"))
+}
+
+func TestWildcardRouteIndexAddKeepsPreferredExistingRoute(t *testing.T) {
+	idx := newWildcardRouteIndex()
+	existing := &preferredFakeHTTPRoute{
+		fakeHTTPRoute: newFakeHTTPRoute(t, "*.example.com", ""),
+		prefer:        true,
+	}
+	shadowed := newFakeHTTPRoute(t, "*.example.com.", "")
+
+	idx.Add(existing)
+	idx.Add(shadowed)
+
+	require.Same(t, existing, idx.Find("app.example.com"))
+}

--- a/internal/net/gphttp/middleware/oidc.go
+++ b/internal/net/gphttp/middleware/oidc.go
@@ -50,15 +50,11 @@ func (amw *oidcMiddleware) init() error {
 
 func (amw *oidcMiddleware) initSlow() error {
 	amw.initMu.Lock()
-	if amw.isInitialized == 1 {
+	if atomic.LoadInt32(&amw.isInitialized) == 1 {
 		amw.initMu.Unlock()
 		return nil
 	}
-
-	defer func() {
-		amw.isInitialized = 1
-		amw.initMu.Unlock()
-	}()
+	defer amw.initMu.Unlock()
 
 	// Always start with the global OIDC provider (for issuer discovery)
 	authProvider, err := auth.NewOIDCProviderFromEnv()
@@ -100,6 +96,7 @@ func (amw *oidcMiddleware) initSlow() error {
 	}
 
 	amw.auth = authProvider
+	atomic.StoreInt32(&amw.isInitialized, 1)
 	return nil
 }
 

--- a/internal/net/gphttp/middleware/oidc_test.go
+++ b/internal/net/gphttp/middleware/oidc_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/yusing/godoxy/internal/common"
 	expect "github.com/yusing/goutils/testing"
 )
@@ -54,22 +55,26 @@ func TestOIDCMiddlewareRetriesAfterInitFailure(t *testing.T) {
 	middleware := &oidcMiddleware{}
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
-	w := httptest.NewRecorder()
-	expect.False(t, middleware.before(w, req))
-	expect.Equal(t, w.Code, http.StatusInternalServerError)
-	expect.Equal(t, middleware.auth, nil)
-	expect.Equal(t, middleware.isInitialized, int32(0))
+	t.Run("first call", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		require.False(t, middleware.before(w, req))
+		require.Equal(t, http.StatusInternalServerError, w.Code)
+		require.Nil(t, middleware.auth)
+		require.Equal(t, int32(0), middleware.isInitialized)
+	})
 
-	w = httptest.NewRecorder()
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Fatalf("middleware.before panicked after prior init failure: %v", r)
-			}
+	t.Run("retry call", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		var panicValue any
+		func() {
+			defer func() {
+				panicValue = recover()
+			}()
+			require.False(t, middleware.before(w, req))
 		}()
-		expect.False(t, middleware.before(w, req))
-	}()
-	expect.Equal(t, w.Code, http.StatusInternalServerError)
-	expect.Equal(t, middleware.auth, nil)
-	expect.Equal(t, middleware.isInitialized, int32(0))
+		require.Nil(t, panicValue, "middleware.before panicked after prior init failure")
+		require.Equal(t, http.StatusInternalServerError, w.Code)
+		require.Nil(t, middleware.auth)
+		require.Equal(t, int32(0), middleware.isInitialized)
+	})
 }

--- a/internal/net/gphttp/middleware/oidc_test.go
+++ b/internal/net/gphttp/middleware/oidc_test.go
@@ -1,8 +1,11 @@
 package middleware
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/yusing/godoxy/internal/common"
 	expect "github.com/yusing/goutils/testing"
 )
 
@@ -32,4 +35,41 @@ func TestOIDCMiddlewarePerRouteConfig(t *testing.T) {
 		expect.Equal(t, middleware.ClientSecret, "")
 		expect.Equal(t, middleware.Scopes, "")
 	})
+}
+
+func TestOIDCMiddlewareRetriesAfterInitFailure(t *testing.T) {
+	previousIssuerURL := common.OIDCIssuerURL
+	previousAllowedUsers := common.OIDCAllowedUsers
+	previousAllowedGroups := common.OIDCAllowedGroups
+	t.Cleanup(func() {
+		common.OIDCIssuerURL = previousIssuerURL
+		common.OIDCAllowedUsers = previousAllowedUsers
+		common.OIDCAllowedGroups = previousAllowedGroups
+	})
+
+	common.OIDCIssuerURL = "http://127.0.0.1:1"
+	common.OIDCAllowedUsers = []string{"user"}
+	common.OIDCAllowedGroups = nil
+
+	middleware := &oidcMiddleware{}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	w := httptest.NewRecorder()
+	expect.False(t, middleware.before(w, req))
+	expect.Equal(t, w.Code, http.StatusInternalServerError)
+	expect.Equal(t, middleware.auth, nil)
+	expect.Equal(t, middleware.isInitialized, int32(0))
+
+	w = httptest.NewRecorder()
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("middleware.before panicked after prior init failure: %v", r)
+			}
+		}()
+		expect.False(t, middleware.before(w, req))
+	}()
+	expect.Equal(t, w.Code, http.StatusInternalServerError)
+	expect.Equal(t, middleware.auth, nil)
+	expect.Equal(t, middleware.isInitialized, int32(0))
 }

--- a/internal/route/README.md
+++ b/internal/route/README.md
@@ -28,7 +28,7 @@ Internal package with stable core types. Route configuration schema is versioned
 
 ```go
 type Route struct {
-    Alias  string       // Unique route identifier
+    Alias  string       // Route lookup key: short alias, FQDN alias, or leading-label wildcard alias (*.example.com)
     Scheme Scheme       // http, https, h2c, tcp, udp, fileserver
     Host   string       // Target host
     Port   Port         // Listen and target ports
@@ -257,6 +257,19 @@ labels:
   proxy.aliases: myapp
   proxy.myapp.port: 3000
 ```
+
+Wildcard HTTP aliases are also supported at route level:
+
+```yaml
+routes:
+  "*.example.com":
+    host: 10.0.0.20
+    port: 8080
+```
+
+- `*.example.com` matches `foo.example.com`
+- it does **not** match `foo.bar.example.com`
+- exact/FQDN and short-alias matches still win before wildcard fallback
 
 ### YAML Configuration
 

--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -45,6 +45,16 @@ import (
 
 type (
 	Route struct {
+		// Alias is route lookup key.
+		//
+		// Supported HTTP host-match forms:
+		//   - short alias: "app"
+		//   - FQDN alias: "app.example.com"
+		//   - leading-label wildcard alias: "*.example.com"
+		//
+		// Wildcard aliases match exactly one leftmost label and are checked only
+		// after normal exact/domain lookup misses, preserving the fast path for
+		// exact routes.
 		Alias  string       `json:"alias"`
 		Scheme route.Scheme `json:"scheme,omitempty" swaggertype:"string" enums:"http,https,h2c,tcp,udp,fileserver"`
 		Host   string       `json:"host,omitempty"`


### PR DESCRIPTION
Support `*.example.com` style aliases that match exactly one leftmost host label after exact alias and FQDN lookup miss. Rebuild a compact wildcard index on route add/remove; skip wildcard keys in the short-link matcher.

Update route README and `Route.Alias` comments with YAML usage and precedence. Add FindRoute tests and benchmarks for wildcard-only, mixed, and exact-precedence cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for leading-label wildcard domain aliases (e.g., *.domain.com) while preserving exact-match fast path.

* **Documentation**
  * Clarified wildcard alias semantics, matching rules, and precedence.

* **Bug Fixes**
  * Middleware initialization no longer marks failed setups as initialized, allowing proper retries.
  * Shortlink handling now ignores wildcard-like aliases for FQDN/subdomain maps.

* **Performance**
  * Precomputed wildcard index to speed fallback lookups.

* **Tests**
  * Added unit tests and benchmarks for wildcard matching, precedence, conflict resolution, and lookup performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yusing/godoxy/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->