### PR TITLE
fix(docs): repair broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,4 +215,4 @@ sh -c "$(curl -fsSL https://github.com/yusing/godoxy/raw/refs/heads/main/scripts
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=yusing/godoxy&type=Date)](https://www.star-history.com/#yusing/godoxy&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=yusing/godoxy&type=Date)](https://star-history.dera.page/#yusing/godoxy&Date)

--- a/README_CHT.md
+++ b/README_CHT.md
@@ -215,4 +215,4 @@ sh -c "$(curl -fsSL https://github.com/yusing/godoxy/raw/refs/heads/main/scripts
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=yusing/godoxy&type=Date)](https://www.star-history.com/#yusing/godoxy&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=yusing/godoxy&type=Date)](https://star-history.dera.page/#yusing/godoxy&Date)


### PR DESCRIPTION
The star history chart on the README pages no longer renders, as the service it relied on is broken due to GitHub stargazer API restrictions. This change points the charts to a working replacement so they display correctly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History charts and badges in the README files to use the new service URL.
  * Updated the associated links to point to the corresponding Star History pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->