### PR TITLE
feat(dnsproviders): add Infomaniak DNS-01 provider

### DIFF
--- a/internal/dnsproviders/gen.py
+++ b/internal/dnsproviders/gen.py
@@ -43,6 +43,7 @@ allowlist = [
     "hostinger",
     "httpreq",
     "ionos",
+    "infomaniak",
     "inwx",
     "linode",
     "namecheap",

--- a/internal/dnsproviders/providers.go
+++ b/internal/dnsproviders/providers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-acme/lego/v5/providers/dns/hetzner"
 	"github.com/go-acme/lego/v5/providers/dns/hostinger"
 	"github.com/go-acme/lego/v5/providers/dns/httpreq"
+	"github.com/go-acme/lego/v5/providers/dns/infomaniak"
 	"github.com/go-acme/lego/v5/providers/dns/inwx"
 	"github.com/go-acme/lego/v5/providers/dns/ionos"
 	"github.com/go-acme/lego/v5/providers/dns/linode"
@@ -59,6 +60,7 @@ func InitProviders() {
 	autocert.Providers["hetzner"] = autocert.DNSProvider(hetzner.NewDefaultConfig, hetzner.NewDNSProviderConfig)
 	autocert.Providers["hostinger"] = autocert.DNSProvider(hostinger.NewDefaultConfig, hostinger.NewDNSProviderConfig)
 	autocert.Providers["httpreq"] = autocert.DNSProvider(httpreq.NewDefaultConfig, httpreq.NewDNSProviderConfig)
+	autocert.Providers["infomaniak"] = autocert.DNSProvider(infomaniak.NewDefaultConfig, infomaniak.NewDNSProviderConfig)
 	autocert.Providers["ionos"] = autocert.DNSProvider(ionos.NewDefaultConfig, ionos.NewDNSProviderConfig)
 	autocert.Providers["inwx"] = autocert.DNSProvider(inwx.NewDefaultConfig, inwx.NewDNSProviderConfig)
 	autocert.Providers["linode"] = autocert.DNSProvider(linode.NewDefaultConfig, linode.NewDNSProviderConfig)


### PR DESCRIPTION
Re-lands #250 onto `main`.

#250 was merged into `feat/lego-v5` after #248 had already been squash-merged to `main`, so Infomaniak never reached `main`. This cherry-picks that same change (`303820e7`) onto current `main`.

Original author: @remcomldr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Infomaniak as a DNS provider.
  * Infomaniak DNS can now be selected and configured for DNS-based operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->